### PR TITLE
fix: handle haptics load failures

### DIFF
--- a/src/components/HomeRuntime.astro
+++ b/src/components/HomeRuntime.astro
@@ -299,11 +299,20 @@
   };
 
   const initializeHaptics = () => {
-    const haptics = window.matchMedia("(pointer: coarse)").matches
-      ? import("web-haptics").then(({ WebHaptics }) =>
-          WebHaptics.isSupported ? new WebHaptics() : null,
-        )
-      : Promise.resolve(null);
+    let hapticsPromise:
+      Promise<import("web-haptics").WebHaptics | null> | undefined;
+    const getHaptics = () => {
+      if (!window.matchMedia("(pointer: coarse)").matches)
+        return Promise.resolve(null);
+      if (!hapticsPromise) {
+        hapticsPromise = import("web-haptics")
+          .then(({ WebHaptics }) =>
+            WebHaptics.isSupported ? new WebHaptics() : null,
+          )
+          .catch(() => null);
+      }
+      return hapticsPromise;
+    };
 
     const assign = (selector: string, pattern: string) => {
       document.querySelectorAll<HTMLElement>(selector).forEach((element) => {
@@ -326,8 +335,11 @@
           return;
         const target = event.target.closest<HTMLElement>("[data-haptic]");
         if (!target) return;
-        const device = await haptics;
-        if (device) void device.trigger(target.dataset.haptic ?? "light");
+        const device = await getHaptics();
+        if (device)
+          void device
+            .trigger(target.dataset.haptic ?? "light")
+            .catch(() => undefined);
       },
       { passive: true },
     );


### PR DESCRIPTION
## Summary

- load `web-haptics` only on the first eligible touch
- degrade silently when its dynamic import fails
- contain rejected haptic trigger promises

## Why

A failed haptics chunk currently becomes an unhandled page error. The integration is optional, so a load or trigger failure should not affect the rest of the portfolio.

This replaces the still-relevant haptics portion of #4 against current `main`. The old PostHog change is intentionally omitted because analytics has since been rewritten and is disabled in development by default.

## Verification

- `bun run ci`
- Playwright touch-device failure injection
  - no haptics request before the first touch
  - blocked haptics request produced no page error
  - theme interaction continued working after the failure