### PR TITLE
perf: refresh GitHub contributions outside SSR

### DIFF
--- a/src/lib/github.test.ts
+++ b/src/lib/github.test.ts
@@ -1,5 +1,154 @@
-import { describe, expect, test } from "bun:test";
-import { buildActivity, parseGithubContributions } from "./github";
+import { describe, expect, mock, spyOn, test } from "bun:test";
+import {
+  buildActivity,
+  fetchGithubContributions,
+  parseGithubContributions,
+  type ContributionCache,
+  type GithubDay,
+} from "./github";
+
+const FRESH_CACHE_URL = "https://itsjan.dev/_cache/github-contributions/fresh";
+const LAST_KNOWN_CACHE_URL =
+  "https://itsjan.dev/_cache/github-contributions/last-known";
+
+function createCache(initial: Record<string, GithubDay[]> = {}): {
+  cache: ContributionCache;
+  values: Map<string, GithubDay[]>;
+} {
+  const values = new Map(Object.entries(initial));
+  const cache: ContributionCache = {
+    async match(request) {
+      const value = values.get(
+        request instanceof Request ? request.url : request.toString(),
+      );
+      return value ? Response.json(value) : undefined;
+    },
+    async put(request, response) {
+      const url = request instanceof Request ? request.url : request.toString();
+      values.set(url, (await response.json()) as GithubDay[]);
+    },
+  };
+
+  return { cache, values };
+}
+
+function contribution(count = 3): GithubDay {
+  return { date: "2026-08-17", level: 2, count };
+}
+
+describe("fetchGithubContributions", () => {
+  test("returns a fresh cache hit without scheduling a refresh", async () => {
+    const { cache } = createCache({
+      [FRESH_CACHE_URL]: [contribution()],
+    });
+    const schedule = mock(() => undefined);
+    const fetcher = mock(() => Promise.resolve(new Response("unused")));
+
+    const result = await fetchGithubContributions(schedule, {
+      cache,
+      fetcher,
+    });
+
+    expect(result).toEqual([contribution()]);
+    expect(schedule).not.toHaveBeenCalled();
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  test("returns a cold-cache fallback before the upstream request settles", async () => {
+    const { cache, values } = createCache();
+    const tasks: Promise<void>[] = [];
+    let resolveUpstream: (response: Response) => void = () => undefined;
+    const upstream = new Promise<Response>((resolve) => {
+      resolveUpstream = resolve;
+    });
+
+    const result = await fetchGithubContributions((task) => tasks.push(task), {
+      cache,
+      fetcher: () => upstream,
+    });
+
+    expect(result).toEqual([]);
+    expect(tasks).toHaveLength(1);
+    expect(values.size).toBe(0);
+
+    resolveUpstream(
+      new Response(
+        '<td class="ContributionCalendar-day" data-date="2026-08-17" data-level="2" data-count="3"></td>',
+      ),
+    );
+    await tasks[0];
+
+    expect(values.get(FRESH_CACHE_URL)).toEqual([contribution()]);
+    expect(values.get(LAST_KNOWN_CACHE_URL)).toEqual([contribution()]);
+  });
+
+  test("serves last-known data when a background refresh times out", async () => {
+    const { cache } = createCache({
+      [LAST_KNOWN_CACHE_URL]: [contribution(7)],
+    });
+    const tasks: Promise<void>[] = [];
+    const errorLog = spyOn(console, "error").mockImplementation(() => {});
+
+    const result = await fetchGithubContributions((task) => tasks.push(task), {
+      cache,
+      fetcher: () => Promise.reject(new Error("request timed out")),
+    });
+    await tasks[0];
+
+    expect(result).toEqual([contribution(7)]);
+    expect(errorLog).toHaveBeenCalledTimes(1);
+    expect(errorLog.mock.calls[0]?.[0]).toContain(
+      "GitHub contribution refresh failed",
+    );
+    errorLog.mockRestore();
+  });
+
+  test("deduplicates concurrent refreshes within an isolate", async () => {
+    const { cache } = createCache();
+    const tasks: Promise<void>[] = [];
+    let resolveUpstream: (response: Response) => void = () => undefined;
+    const upstream = new Promise<Response>((resolve) => {
+      resolveUpstream = resolve;
+    });
+    const fetcher = mock(() => upstream);
+
+    const [first, second] = await Promise.all([
+      fetchGithubContributions((task) => tasks.push(task), { cache, fetcher }),
+      fetchGithubContributions((task) => tasks.push(task), { cache, fetcher }),
+    ]);
+
+    expect(first).toEqual([]);
+    expect(second).toEqual([]);
+    expect(tasks).toHaveLength(1);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+
+    resolveUpstream(
+      new Response(
+        '<td class="ContributionCalendar-day" data-date="2026-08-17" data-level="2" data-count="3"></td>',
+      ),
+    );
+    await tasks[0];
+  });
+
+  test("treats cache read failures as misses", async () => {
+    const cache: ContributionCache = {
+      match: () => Promise.reject(new Error("cache unavailable")),
+      put: () => Promise.resolve(),
+    };
+    const tasks: Promise<void>[] = [];
+    const errorLog = spyOn(console, "error").mockImplementation(() => {});
+
+    const result = await fetchGithubContributions((task) => tasks.push(task), {
+      cache,
+      fetcher: () => Promise.reject(new Error("upstream unavailable")),
+    });
+    await tasks[0];
+
+    expect(result).toEqual([]);
+    expect(tasks).toHaveLength(1);
+    errorLog.mockRestore();
+  });
+});
 
 describe("parseGithubContributions", () => {
   test("reads tooltip counts, direct counts and clamps levels", () => {

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -15,50 +15,147 @@ export type ActivityDay = {
 };
 
 const CONTRIBUTIONS_URL = `https://github.com/users/${SOCIAL_HANDLES.github}/contributions`;
-const CACHE_URL = `${SITE_ORIGIN}/_cache/github-contributions`;
+const FRESH_CACHE_URL = `${SITE_ORIGIN}/_cache/github-contributions/fresh`;
+const LAST_KNOWN_CACHE_URL = `${SITE_ORIGIN}/_cache/github-contributions/last-known`;
 const CACHE_SECONDS = 15 * 60;
+const LAST_KNOWN_CACHE_SECONDS = 7 * 24 * 60 * 60;
 const FALLBACK_DAYS = 365;
 const ACTIVITY_ROWS = 7;
+const activeRefreshes = new Set<string>();
 
-export async function fetchGithubContributions(): Promise<GithubDay[]> {
-  const cache = getEdgeCache();
-  const cacheKey = new Request(CACHE_URL);
+export type ContributionCache = Pick<Cache, "match" | "put">;
 
+type GithubContributionOptions = {
+  cache?: ContributionCache;
+  fetcher?: GithubFetcher;
+};
+
+type GithubFetcher = (
+  input: string | URL | Request,
+  init?: RequestInit,
+) => Promise<Response>;
+
+export type BackgroundScheduler = (task: Promise<void>) => void;
+
+export async function fetchGithubContributions(
+  schedule: BackgroundScheduler,
+  options: GithubContributionOptions = {},
+): Promise<GithubDay[]> {
+  const cache = options.cache ?? getEdgeCache();
+  const freshCacheKey = new Request(FRESH_CACHE_URL);
+  const lastKnownCacheKey = new Request(LAST_KNOWN_CACHE_URL);
+  const fresh = await readCachedContributions(cache, freshCacheKey);
+
+  if (fresh) return fresh;
+
+  const lastKnown = await readCachedContributions(cache, lastKnownCacheKey);
+  scheduleRefresh(schedule, {
+    cache,
+    fetcher: options.fetcher ?? fetch,
+    freshCacheKey,
+    lastKnownCacheKey,
+  });
+
+  return lastKnown ?? [];
+}
+
+type RefreshOptions = Required<
+  Pick<GithubContributionOptions, "cache" | "fetcher">
+> & {
+  freshCacheKey: Request;
+  lastKnownCacheKey: Request;
+};
+
+function scheduleRefresh(
+  schedule: BackgroundScheduler,
+  options: RefreshOptions,
+): void {
+  if (activeRefreshes.has(FRESH_CACHE_URL)) return;
+  activeRefreshes.add(FRESH_CACHE_URL);
+
+  const refresh = refreshContributions(options)
+    .catch((error: unknown) => {
+      console.error(
+        JSON.stringify({
+          message: "GitHub contribution refresh failed",
+          error: error instanceof Error ? error.message : String(error),
+        }),
+      );
+    })
+    .finally(() => activeRefreshes.delete(FRESH_CACHE_URL));
+
+  schedule(refresh);
+}
+
+async function refreshContributions({
+  cache,
+  fetcher,
+  freshCacheKey,
+  lastKnownCacheKey,
+}: RefreshOptions): Promise<void> {
+  const response = await fetcher(CONTRIBUTIONS_URL, {
+    headers: {
+      accept: "text/html",
+      "user-agent": `${new URL(SITE_ORIGIN).hostname} contribution graph`,
+    },
+    signal: AbortSignal.timeout(5_000),
+  });
+  if (!response.ok) throw new Error(`GitHub returned HTTP ${response.status}`);
+
+  const contributions = parseGithubContributions(await response.text());
+  if (!contributions.length) {
+    throw new Error("GitHub returned no contribution days");
+  }
+
+  await Promise.all([
+    writeCachedContributions(
+      cache,
+      freshCacheKey,
+      contributions,
+      CACHE_SECONDS,
+    ),
+    writeCachedContributions(
+      cache,
+      lastKnownCacheKey,
+      contributions,
+      LAST_KNOWN_CACHE_SECONDS,
+    ),
+  ]);
+}
+
+async function readCachedContributions(
+  cache: ContributionCache,
+  cacheKey: Request,
+): Promise<GithubDay[] | undefined> {
   try {
-    const cached = await cache?.match(cacheKey);
-    if (cached) {
-      const data: unknown = await cached.json();
-      if (Array.isArray(data)) return data.filter(isGithubDay);
-    }
+    const cached = await cache.match(cacheKey);
+    if (!cached) return undefined;
 
-    const response = await fetch(CONTRIBUTIONS_URL, {
-      headers: {
-        accept: "text/html",
-        "user-agent": `${new URL(SITE_ORIGIN).hostname} contribution graph`,
-      },
-      signal: AbortSignal.timeout(5_000),
-    });
-    if (!response.ok) return [];
+    const data: unknown = await cached.json();
+    if (!Array.isArray(data)) return undefined;
 
-    const contributions = parseGithubContributions(await response.text());
-    if (contributions.length && cache) {
-      try {
-        await cache.put(
-          cacheKey,
-          Response.json(contributions, {
-            headers: {
-              "Cache-Control": `public, max-age=${CACHE_SECONDS}, stale-while-revalidate=${CACHE_SECONDS}`,
-            },
-          }),
-        );
-      } catch {
-        // A cache write should never discard a successful GitHub response.
-      }
-    }
-
-    return contributions;
+    const contributions = data.filter(isGithubDay);
+    return contributions.length ? contributions : undefined;
   } catch {
-    return [];
+    return undefined;
+  }
+}
+
+async function writeCachedContributions(
+  cache: ContributionCache,
+  cacheKey: Request,
+  contributions: GithubDay[],
+  maxAge: number,
+): Promise<void> {
+  try {
+    await cache.put(
+      cacheKey,
+      Response.json(contributions, {
+        headers: { "Cache-Control": `public, max-age=${maxAge}` },
+      }),
+    );
+  } catch {
+    // Cache failures should not turn a successful refresh into a page failure.
   }
 }
 
@@ -150,9 +247,18 @@ export function parseGithubContributions(html: string): GithubDay[] {
   return [...daysByDate.values()].sort((a, b) => a.date.localeCompare(b.date));
 }
 
-function getEdgeCache(): Cache | undefined {
-  return (globalThis.caches as (CacheStorage & { default?: Cache }) | undefined)
-    ?.default;
+function getEdgeCache(): ContributionCache {
+  const cache = (
+    globalThis.caches as (CacheStorage & { default?: Cache }) | undefined
+  )?.default;
+  return cache ?? createNoopCache();
+}
+
+function createNoopCache(): ContributionCache {
+  return {
+    match: () => Promise.resolve(undefined),
+    put: () => Promise.resolve(),
+  };
 }
 
 function isGithubDay(value: unknown): value is GithubDay {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -39,7 +39,9 @@ import {
 const locale = detectLocale(Astro.request);
 const copy = tr(locale).portfolio;
 const currentAge = ageYears();
-const githubDays = await fetchGithubContributions();
+const githubDays = await fetchGithubContributions((task) =>
+  Astro.locals.cfContext.waitUntil(task),
+);
 const technologies = createTechnologyCollections(copy.tech.items);
 const activity = buildActivity(githubDays, locale, copy.activity);
 const stickerLayout = createStickerLayout(copy.tech.items.length);


### PR DESCRIPTION
## Summary

- serve fresh or last-known contribution data directly from the edge cache
- schedule upstream GitHub refreshes with Cloudflare `waitUntil`
- keep a seven-day fallback and deduplicate concurrent refreshes per isolate
- add coverage for cold cache, timeout, cache failure, and concurrency

## Validation

- `bun run ci`
- desktop and mobile Playwright smoke tests against `http://localhost:4321/`
- no browser console errors or warnings

Closes #14