### PR TITLE
perf(a11y): render a single responsive activity graph

### DIFF
--- a/src/components/ActivityGraph.astro
+++ b/src/components/ActivityGraph.astro
@@ -1,0 +1,68 @@
+---
+import type { ActivityDay } from "../lib/github";
+import { activityRevealOrder } from "../lib/github";
+
+interface Props {
+  activity: ActivityDay[];
+  ariaLabel: string;
+  lessLabel: string;
+  moreLabel: string;
+}
+
+const { activity, ariaLabel, lessLabel, moreLabel } = Astro.props;
+---
+
+<div class="mt-6">
+  <div class="activity-scroll">
+    <div
+      class="t-skel activity-reveal"
+      data-state="loading"
+      role="img"
+      aria-label={ariaLabel}
+    >
+      <div class="activity-grid" aria-hidden="true">
+        {
+          activity.map((day, index) =>
+            day.count > 0 ? (
+              <span class="t-tt-wrap activity-tooltip-wrap">
+                <span
+                  class="activity-day t-tt-trigger"
+                  data-cuelume-hover="tick"
+                  data-level={day.level}
+                  data-project={day.project}
+                  style={`--activity-order:${activityRevealOrder(index)}`}
+                />
+                <span class="t-tt activity-tooltip" role="tooltip">
+                  {day.label}
+                </span>
+              </span>
+            ) : (
+              <span
+                class="activity-day"
+                data-level={day.level}
+                data-project={day.project}
+                style={`--activity-order:${activityRevealOrder(index)}`}
+              />
+            ),
+          )
+        }
+      </div>
+    </div>
+  </div>
+  <div
+    class="activity-legend mt-2 flex items-center justify-end gap-1 [font-family:Geist_Mono,ui-monospace,monospace] text-[10px] text-[var(--text-tertiary)]"
+    aria-hidden="true"
+  >
+    <span>{lessLabel}</span><i
+      class="block size-[7px] rounded-[2px] max-[520px]:size-[5px] max-[520px]:rounded-[1.5px]"
+      data-level="0"></i><i
+      class="block size-[7px] rounded-[2px] max-[520px]:size-[5px] max-[520px]:rounded-[1.5px]"
+      data-level="1"></i><i
+      class="block size-[7px] rounded-[2px] max-[520px]:size-[5px] max-[520px]:rounded-[1.5px]"
+      data-level="2"></i><i
+      class="block size-[7px] rounded-[2px] max-[520px]:size-[5px] max-[520px]:rounded-[1.5px]"
+      data-level="3"></i><i
+      class="block size-[7px] rounded-[2px] max-[520px]:size-[5px] max-[520px]:rounded-[1.5px]"
+      data-level="4"></i><span>{moreLabel}</span>
+  </div>
+</div>

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -58,8 +58,7 @@ interface Strings {
     };
     activity: {
       heading: string;
-      desktopAria: string;
-      mobileAria: string;
+      aria: string;
       less: string;
       more: string;
       contribution: string;
@@ -205,8 +204,7 @@ const en: Strings = {
     },
     activity: {
       heading: "My year on GitHub",
-      desktopAria: "My GitHub contributions over the past year",
-      mobileAria: "My GitHub contributions over the past year",
+      aria: "My GitHub contributions over the past year",
       less: "Less",
       more: "More",
       contribution: "contribution",
@@ -356,8 +354,7 @@ const de: Strings = {
     },
     activity: {
       heading: "Mein Jahr auf GitHub",
-      desktopAria: "Meine GitHub-Beiträge im letzten Jahr",
-      mobileAria: "Meine GitHub-Beiträge im letzten Jahr",
+      aria: "Meine GitHub-Beiträge im letzten Jahr",
       less: "Weniger",
       more: "Mehr",
       contribution: "Beitrag",

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from "../layouts/Layout.astro";
+import ActivityGraph from "../components/ActivityGraph.astro";
 import EdgeBlur from "../components/EdgeBlur.astro";
 import HomeRuntime from "../components/HomeRuntime.astro";
 import InteractiveButton from "../components/InteractiveButton.astro";
@@ -17,11 +18,7 @@ import teamNeustaLogo from "../assets/team-neusta-orb.svg";
 import ventryLogo from "../assets/ventry-logo-white-56.png";
 import { detectLocale, tr } from "../lib/i18n";
 import { ageYears } from "../lib/jan";
-import {
-  activityRevealOrder,
-  buildActivity,
-  fetchGithubContributions,
-} from "../lib/github";
+import { buildActivity, fetchGithubContributions } from "../lib/github";
 import {
   CONTACT_EMAIL,
   CONTACT_MAILTO,
@@ -44,6 +41,8 @@ const githubDays = await fetchGithubContributions((task) =>
 );
 const technologies = createTechnologyCollections(copy.tech.items);
 const activity = buildActivity(githubDays, locale, copy.activity);
+const activityTotal = activity.reduce((total, day) => total + day.count, 0);
+const activityAriaLabel = `${copy.activity.aria}: ${new Intl.NumberFormat(locale).format(activityTotal)} ${activityTotal === 1 ? copy.activity.contribution : copy.activity.contributions}`;
 const stickerLayout = createStickerLayout(copy.tech.items.length);
 const linkedinUrl =
   locale === "en"
@@ -607,145 +606,12 @@ const llmsTooltipTitle = new URL(llmsUrl).host;
         <h2 class="text-2xl font-medium tracking-tight text-[var(--text)]">
           {copy.activity.heading}
         </h2>
-        <div class="mt-6">
-          <div
-            class="activity-scroll activity-scroll-desktop"
-            role="group"
-            aria-label={copy.activity.desktopAria}
-          >
-            <div class="t-skel activity-reveal" data-state="loading">
-              <div
-                class="t-skel-skeleton is-pulsing activity-grid"
-                aria-hidden="true"
-              >
-                {
-                  activity.map((_, index) => (
-                    <span
-                      class="activity-day"
-                      data-level="0"
-                      style={`--activity-order:${activityRevealOrder(index)}`}
-                    />
-                  ))
-                }
-              </div>
-              <div class="t-skel-content activity-grid">
-                {
-                  activity.map((day, index) =>
-                    day.count > 0 ? (
-                      <span class="t-tt-wrap activity-tooltip-wrap">
-                        <span
-                          class="activity-day t-tt-trigger"
-                          data-cuelume-hover="tick"
-                          data-level={day.level}
-                          data-project={day.project}
-                          role="img"
-                          aria-label={day.label}
-                          aria-describedby={`activity-tooltip-desktop-${index}`}
-                          tabindex="0"
-                          style={`--activity-order:${activityRevealOrder(index)}`}
-                        />
-                        <span
-                          id={`activity-tooltip-desktop-${index}`}
-                          class="t-tt activity-tooltip"
-                          role="tooltip"
-                        >
-                          {day.label}
-                        </span>
-                      </span>
-                    ) : (
-                      <span
-                        class="activity-day"
-                        data-level={day.level}
-                        data-project={day.project}
-                        role="img"
-                        aria-label={day.label}
-                        style={`--activity-order:${activityRevealOrder(index)}`}
-                      />
-                    ),
-                  )
-                }
-              </div>
-            </div>
-          </div>
-          <div
-            class="activity-scroll activity-scroll-mobile"
-            role="group"
-            aria-label={copy.activity.mobileAria}
-          >
-            <div
-              class="t-skel activity-reveal activity-reveal-mobile"
-              data-state="loading"
-            >
-              <div
-                class="t-skel-skeleton is-pulsing activity-grid activity-grid-mobile"
-                aria-hidden="true"
-              >
-                {
-                  activity.map((_, index) => (
-                    <span
-                      class="activity-day"
-                      data-level="0"
-                      style={`--activity-order:${activityRevealOrder(index)}`}
-                    />
-                  ))
-                }
-              </div>
-              <div class="t-skel-content activity-grid activity-grid-mobile">
-                {
-                  activity.map((day, index) =>
-                    day.count > 0 ? (
-                      <span class="t-tt-wrap activity-tooltip-wrap">
-                        <span
-                          class="activity-day t-tt-trigger"
-                          data-cuelume-hover="tick"
-                          data-level={day.level}
-                          data-project={day.project}
-                          role="img"
-                          aria-label={day.label}
-                          aria-describedby={`activity-tooltip-mobile-${index}`}
-                          tabindex="0"
-                          style={`--activity-order:${activityRevealOrder(index)}`}
-                        />
-                        <span
-                          id={`activity-tooltip-mobile-${index}`}
-                          class="t-tt activity-tooltip"
-                          role="tooltip"
-                        >
-                          {day.label}
-                        </span>
-                      </span>
-                    ) : (
-                      <span
-                        class="activity-day"
-                        data-level={day.level}
-                        data-project={day.project}
-                        role="img"
-                        aria-label={day.label}
-                        style={`--activity-order:${activityRevealOrder(index)}`}
-                      />
-                    ),
-                  )
-                }
-              </div>
-            </div>
-          </div>
-          <div
-            class="activity-legend mt-2 flex items-center justify-end gap-1 [font-family:Geist_Mono,ui-monospace,monospace] text-[10px] text-[var(--text-tertiary)]"
-            aria-hidden="true"
-          >
-            <span>{copy.activity.less}</span><i
-              class="block size-[7px] rounded-[2px] max-[520px]:size-[5px] max-[520px]:rounded-[1.5px]"
-              data-level="0"></i><i
-              class="block size-[7px] rounded-[2px] max-[520px]:size-[5px] max-[520px]:rounded-[1.5px]"
-              data-level="1"></i><i
-              class="block size-[7px] rounded-[2px] max-[520px]:size-[5px] max-[520px]:rounded-[1.5px]"
-              data-level="2"></i><i
-              class="block size-[7px] rounded-[2px] max-[520px]:size-[5px] max-[520px]:rounded-[1.5px]"
-              data-level="3"></i><i
-              class="block size-[7px] rounded-[2px] max-[520px]:size-[5px] max-[520px]:rounded-[1.5px]"
-              data-level="4"></i><span>{copy.activity.more}</span>
-          </div>
-        </div>
+        <ActivityGraph
+          {activity}
+          ariaLabel={activityAriaLabel}
+          lessLabel={copy.activity.less}
+          moreLabel={copy.activity.more}
+        />
       </section>
       <WaveDivider />
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1213,9 +1213,6 @@ html[data-theme="dark"] .ventry-file-row b {
   overflow: visible;
   padding: 10px 0 8px;
 }
-.activity-scroll-mobile {
-  display: none;
-}
 .activity-grid {
   display: grid;
   grid-auto-flow: column;
@@ -1312,91 +1309,21 @@ html[data-theme="dark"] .ventry-file-row b {
 }
 /* transitions.dev: skeleton loader and reveal */
 .activity-reveal {
+  position: relative;
   width: 100%;
   min-height: 67px;
 }
-.t-skel {
-  position: relative;
-}
-.t-skel-skeleton,
-.t-skel-content {
-  position: absolute;
-  inset: 0;
-}
-
-.t-skel-skeleton {
-  z-index: 1;
-  opacity: 1;
-  filter: blur(0);
-  clip-path: inset(0 0 0 0);
-  transition:
-    opacity var(--reveal-dur) var(--reveal-ease),
-    filter var(--reveal-dur) var(--reveal-ease),
-    clip-path var(--reveal-dur) var(--reveal-ease);
-}
-.t-skel-content {
-  z-index: 2;
-  opacity: 0;
-  filter: blur(var(--reveal-blur));
-  clip-path: inset(0 100% 0 0);
-  transition:
-    opacity var(--reveal-dur) var(--reveal-ease),
-    filter var(--reveal-dur) var(--reveal-ease),
-    clip-path var(--reveal-dur) var(--reveal-ease);
-}
-.t-skel.is-revealed .t-skel-skeleton {
-  opacity: 1;
-  filter: blur(var(--reveal-blur));
-  clip-path: inset(0 0 0 100%);
-}
-.t-skel.is-revealed .t-skel-content {
-  opacity: 1;
-  filter: blur(0);
-  clip-path: inset(0 0 0 0);
-}
-.activity-reveal.t-skel .t-skel-skeleton,
-.activity-reveal.t-skel .t-skel-content,
-.activity-reveal.t-skel.is-revealed .t-skel-skeleton,
-.activity-reveal.t-skel.is-revealed .t-skel-content {
-  opacity: 1;
-  filter: none;
-  clip-path: none;
-  transition: none;
-}
-.t-skel-skeleton.is-pulsing {
+.activity-reveal:not(.is-revealed) .activity-grid {
   animation: t-skel-pulse var(--pulse-dur) ease-in-out var(--pulse-count);
 }
-.activity-reveal.t-skel .t-skel-skeleton .activity-day,
-.activity-reveal.t-skel .t-skel-content .activity-day {
-  transition-delay: calc(var(--activity-order) * var(--activity-reveal-step));
+.activity-reveal:not(.is-revealed) .activity-day {
+  background: var(--activity-0);
 }
-.activity-reveal.t-skel .t-skel-skeleton .activity-day {
-  transition: opacity var(--activity-reveal-duration) var(--reveal-ease);
-  opacity: 1;
-}
-.activity-reveal.t-skel .t-skel-content .activity-day {
-  transition-property: opacity, filter;
+.activity-reveal .activity-day {
+  transition-property: background-color;
   transition-duration: var(--activity-reveal-duration);
   transition-timing-function: var(--reveal-ease);
-  opacity: 0;
-  filter: blur(var(--reveal-blur));
-}
-.activity-reveal.t-skel .activity-day {
   transition-delay: calc(var(--activity-order) * var(--activity-reveal-step));
-}
-.activity-reveal.t-skel.is-revealed .t-skel-skeleton .activity-day {
-  opacity: 1;
-}
-.activity-reveal.t-skel.is-revealed .t-skel-content .activity-day {
-  opacity: 1;
-  filter: blur(0);
-}
-.activity-reveal.t-skel.is-revealed
-  .t-skel-content
-  .activity-day[data-level="0"] {
-  opacity: 0;
-  filter: none;
-  transition: none;
 }
 @keyframes t-skel-pulse {
   0%,
@@ -2566,19 +2493,13 @@ html[data-theme="dark"] .social-card-linkedin-action {
   .project-preview-image .ventry-file-panel {
     display: none;
   }
-  .activity-scroll-desktop {
-    display: none;
-  }
-  .activity-scroll-mobile {
-    display: block;
-  }
-  .activity-grid-mobile {
+  .activity-grid {
     grid-template-rows: repeat(7, 5px);
     grid-auto-columns: 5px;
     column-gap: 0;
     row-gap: 2px;
   }
-  .activity-grid-mobile .activity-day {
+  .activity-grid .activity-day {
     border-radius: 1.5px;
   }
   .activity-tooltip {
@@ -2588,7 +2509,7 @@ html[data-theme="dark"] .social-card-linkedin-action {
     text-align: center;
     white-space: normal;
   }
-  .activity-reveal-mobile {
+  .activity-reveal {
     min-height: 47px;
   }
   .preview-receipt {
@@ -2653,14 +2574,10 @@ html[data-theme="dark"] .social-card-linkedin-action {
     animation: none !important;
     clip-path: none !important;
   }
-  .t-skel-skeleton,
-  .t-skel-content {
-    transition: none !important;
-  }
-  .t-skel-skeleton.is-pulsing {
+  .activity-reveal:not(.is-revealed) .activity-grid {
     animation: none !important;
   }
-  .activity-reveal.t-skel .activity-day {
+  .activity-reveal .activity-day {
     transition: none !important;
   }
   .t-tt {


### PR DESCRIPTION
## Summary

- replace four duplicated activity cell grids with one responsive graph
- use the real grid itself as the CSS skeleton so loading and rendered geometry match exactly
- keep empty contribution days visible
- expose a localized contribution summary as one accessible image instead of hundreds of tab stops
- extract the graph into a focused Astro component

## Measured impact

- homepage HTML: ~420 KB → ~256 KB
- document elements: 2,805 → 1,556
- activity-related keyboard tab stops: 146 → 0
- rendered graph instances: 4 → 1

## Validation

- `bun run ci`
- desktop and mobile Playwright checks
- skeleton/final cell positions and dimensions match
- empty days remain visible
- contribution tooltip hover remains functional
- no browser console errors or warnings

Closes #11