### PR TITLE
chore: enable type-aware ESLint rules

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,7 +8,10 @@ export default [
     ignores: [".astro/**", ".wrangler/**", "dist/**", "node_modules/**"],
   },
   js.configs.recommended,
-  ...tseslint.configs.recommended,
+  ...tseslint.configs.recommendedTypeChecked.map((config) => ({
+    ...config,
+    files: ["**/*.{ts,tsx,mts,cts}"],
+  })),
   ...astro.configs.recommended,
   {
     files: ["**/*.{js,mjs,ts,astro}"],
@@ -24,12 +27,32 @@ export default [
     },
   },
   {
+    files: ["**/*.{ts,tsx,mts,cts}"],
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      "@typescript-eslint/no-floating-promises": "error",
+    },
+  },
+  {
     files: ["**/*.astro"],
+    plugins: {
+      "@typescript-eslint": tseslint.plugin,
+    },
     languageOptions: {
       parserOptions: {
         parser: tseslint.parser,
         extraFileExtensions: [".astro"],
+        project: "./tsconfig.json",
+        tsconfigRootDir: import.meta.dirname,
       },
+    },
+    rules: {
+      "@typescript-eslint/no-floating-promises": "error",
     },
   },
 ];

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -23,7 +23,7 @@ interface Props {
   noindex?: boolean;
 }
 
-const props = Astro.props as Props;
+const props: Props = Astro.props;
 const locale = detectLocale(Astro.request);
 const copy = tr(locale);
 const title =

--- a/src/lib/github.test.ts
+++ b/src/lib/github.test.ts
@@ -17,11 +17,11 @@ function createCache(initial: Record<string, GithubDay[]> = {}): {
 } {
   const values = new Map(Object.entries(initial));
   const cache: ContributionCache = {
-    async match(request) {
+    match(request) {
       const value = values.get(
         request instanceof Request ? request.url : request.toString(),
       );
-      return value ? Response.json(value) : undefined;
+      return Promise.resolve(value ? Response.json(value) : undefined);
     },
     async put(request, response) {
       const url = request instanceof Request ? request.url : request.toString();

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, mock, test } from "bun:test";
 
-mock.module("astro:middleware", () => ({
+await mock.module("astro:middleware", () => ({
   defineMiddleware: <Middleware>(middleware: Middleware) => middleware,
 }));
 


### PR DESCRIPTION
## Summary

- enable the recommended type-checked TypeScript ESLint rules for TypeScript files
- use TypeScript project service for source and test files
- enable typed `no-floating-promises` checks in Astro scripts through the Astro parser
- keep the full type-aware preset scoped away from Astro template expressions that cannot be resolved reliably
- fix the newly exposed floating mock setup, unnecessary assertion, and async-without-await findings

## Validation

- effective ESLint config confirms project-backed parsing and `no-floating-promises: error` for TypeScript and Astro
- `bun run ci`
- no lint warnings
- 20 unit tests and browser integration smoke pass

Closes #16