### PR TITLE
refactor: introduce stable content IDs

### DIFF
--- a/scripts/check-content.mjs
+++ b/scripts/check-content.mjs
@@ -28,15 +28,18 @@ const discoveryPath = new URL(
   import.meta.url,
 );
 const headersPath = new URL("../public/_headers", import.meta.url);
+const privacyPagePath = new URL("../src/pages/privacy.astro", import.meta.url);
 
-const [skill, discoverySource, headers, ...publicTexts] = await Promise.all([
-  readFile(skillPath),
-  readFile(discoveryPath, "utf8"),
-  readFile(headersPath, "utf8"),
-  ...publicTextResources.map(({ path }) =>
-    readFile(new URL(path, import.meta.url)),
-  ),
-]);
+const [skill, discoverySource, headers, privacyPage, ...publicTexts] =
+  await Promise.all([
+    readFile(skillPath),
+    readFile(discoveryPath, "utf8"),
+    readFile(headersPath, "utf8"),
+    readFile(privacyPagePath, "utf8"),
+    ...publicTextResources.map(({ path }) =>
+      readFile(new URL(path, import.meta.url)),
+    ),
+  ]);
 
 const discovery = JSON.parse(discoverySource);
 const publishedDigest = discovery.skills?.find(
@@ -231,6 +234,57 @@ if (englishProfile !== indexProfile) {
   );
 }
 
+const privacyRepresentations = {
+  de: {
+    markdown: utf8.decode(publicTexts[6]),
+    date: "12. August 2026",
+    headings: [
+      "Datenschutzerklärung",
+      "Verantwortlicher",
+      "Hosting",
+      "Reichweitenmessung mit PostHog",
+      "Fehlerdiagnose",
+      "Ihre Rechte",
+    ],
+  },
+  en: {
+    markdown: utf8.decode(publicTexts[7]),
+    date: "12 August 2026",
+    headings: [
+      "Privacy policy",
+      "Controller",
+      "Hosting",
+      "Analytics with PostHog",
+      "Error diagnostics",
+      "Your rights",
+    ],
+  },
+};
+const privacyLinks = [
+  "mailto:hi@itsjan.dev",
+  "https://www.cloudflare.com/privacypolicy/",
+  "https://posthog.com/privacy",
+  "https://posthog.com/dpa",
+];
+
+Object.entries(privacyRepresentations).forEach(
+  ([locale, { markdown, date, headings }]) => {
+    const requiredValues = [date, ...headings, ...privacyLinks];
+    requiredValues.forEach((value) => {
+      if (!markdown.includes(value)) {
+        errors.push(
+          `src/content/resources/privacy.${locale}.md is missing shared privacy value: ${value}`,
+        );
+      }
+      if (!privacyPage.includes(value)) {
+        errors.push(
+          `src/pages/privacy.astro is missing the ${locale} privacy value: ${value}`,
+        );
+      }
+    });
+  },
+);
+
 if (!headers.includes("Content-Type: text/markdown; charset=utf-8")) {
   errors.push("public/_headers must declare UTF-8 for Markdown resources.");
 }
@@ -243,6 +297,6 @@ if (errors.length > 0) {
   process.exitCode = 1;
 } else {
   process.stdout.write(
-    `Content resources use consistent languages and valid UTF-8; Agent Skill digest is current.\n`,
+    `Content resources use consistent languages and valid UTF-8; privacy representations and Agent Skill digest are current.\n`,
   );
 }

--- a/src/components/CookieConsent.astro
+++ b/src/components/CookieConsent.astro
@@ -1,5 +1,5 @@
 ---
-import type { Locale } from "../lib/i18n";
+import { tr, type Locale } from "../lib/i18n";
 import InteractiveButton from "./InteractiveButton.astro";
 import InteractiveLink from "./InteractiveLink.astro";
 import WaveDivider from "./WaveDivider.astro";
@@ -10,26 +10,7 @@ interface Props {
 }
 
 const { locale } = Astro.props;
-const copy =
-  locale === "de"
-    ? {
-        title: "Datenschutz-Einstellungen",
-        text: "Mit Ihrer Zustimmung lade ich PostHog. So sehe ich, welche Bereiche genutzt werden und wo technische Fehler auftreten.",
-        accept: "Analyse erlauben",
-        reject: "Nur notwendige Cookies",
-        settings: "Datenschutz-Einstellungen",
-        settingsShort: "Datenschutz",
-        privacy: "Datenschutzerklärung",
-      }
-    : {
-        title: "Privacy settings",
-        text: "With your permission, I use PostHog to see which parts of the site people use and where technical errors occur.",
-        accept: "Allow analytics",
-        reject: "Necessary cookies only",
-        settings: "Privacy settings",
-        settingsShort: "Privacy",
-        privacy: "Privacy policy",
-      };
+const copy = tr(locale).privacyConsent;
 ---
 
 <aside

--- a/src/components/home/ExperienceSection.astro
+++ b/src/components/home/ExperienceSection.astro
@@ -13,8 +13,8 @@ interface Props {
 }
 
 const { experience, technologyAriaLabel, technologies } = Astro.props;
-const technologiesByName = new Map(
-  technologies.map((technology) => [technology.name, technology]),
+const technologiesById = new Map(
+  technologies.map((technology) => [technology.id, technology]),
 );
 ---
 
@@ -38,12 +38,11 @@ const technologiesByName = new Map(
             <span
               class:list={[
                 "experience-organization inline-flex items-center gap-0.5",
-                ["Finny", "Ventry", "team neusta"].includes(
-                  item.organization,
-                ) && "experience-organization--with-logo",
+                item.organizationId !== "homelab" &&
+                  "experience-organization--with-logo",
               ]}
             >
-              {item.organization === "Finny" && (
+              {item.organizationId === "finny" && (
                 <Image
                   src={finnyFavicon}
                   alt=""
@@ -52,14 +51,14 @@ const technologiesByName = new Map(
                   class="experience-organization-mark"
                 />
               )}
-              {item.organization.toLowerCase() === "team neusta" && (
+              {item.organizationId === "team-neusta" && (
                 <span
                   class="experience-organization-mark experience-organization-logo"
                   style={`--experience-organization-logo: url(${teamNeustaLogo.src})`}
                   aria-hidden="true"
                 />
               )}
-              {item.organization === "Ventry" && (
+              {item.organizationId === "ventry" && (
                 <span
                   class="experience-organization-mark experience-organization-logo"
                   style={`--experience-organization-logo: url(${ventryLogo.src})`}
@@ -93,7 +92,7 @@ const technologiesByName = new Map(
             aria-label={technologyAriaLabel}
           >
             {item.technologies
-              .map((name) => technologiesByName.get(name))
+              .map((id) => technologiesById.get(id))
               .map((technology) => {
                 if (!technology) return null;
                 const Logo = technology.logo;

--- a/src/components/home/ProjectsSection.astro
+++ b/src/components/home/ProjectsSection.astro
@@ -2,8 +2,8 @@
 import { Image } from "astro:assets";
 import finnyFavicon from "../../assets/finny-favicon.png";
 import ventryLogo from "../../assets/ventry-logo-white-56.png";
+import { PROJECTS } from "../../data/portfolio";
 import type { PortfolioCopy } from "../../lib/i18n";
-import { FINNY_URL, VENTRY_URL } from "../../lib/site";
 import InteractiveLink from "../InteractiveLink.astro";
 
 interface Props {
@@ -61,12 +61,13 @@ const { heading, finny, ventry } = Astro.props;
           <div class="project-preview-action">
             <InteractiveLink
               variant="primary"
-              href={FINNY_URL}
+              href={PROJECTS[finny.id].href}
               target="_blank"
               rel="noreferrer"
               class="project-preview-cta"
               data-analytics-event="project_cta_clicked"
-              data-analytics-project="finny">{finny.cta.label}</InteractiveLink
+              data-analytics-project={finny.id}
+              >{finny.cta.label}</InteractiveLink
             >
           </div>
         </div>
@@ -142,12 +143,12 @@ const { heading, finny, ventry } = Astro.props;
           <div class="project-preview-action">
             <InteractiveLink
               variant="primary"
-              href={VENTRY_URL}
+              href={PROJECTS[ventry.id].href}
               target="_blank"
               rel="noreferrer"
               class="project-preview-cta"
               data-analytics-event="project_cta_clicked"
-              data-analytics-project="ventry"
+              data-analytics-project={ventry.id}
               >{ventry.cta.label}</InteractiveLink
             >
           </div>

--- a/src/data/portfolio.ts
+++ b/src/data/portfolio.ts
@@ -1,0 +1,26 @@
+import { FINNY_URL, VENTRY_URL } from "../lib/site";
+
+export const PROJECTS = {
+  finny: { id: "finny", href: FINNY_URL },
+  ventry: { id: "ventry", href: VENTRY_URL },
+} as const;
+
+export type ProjectId = keyof typeof PROJECTS;
+
+export const ORGANIZATION_IDS = [
+  "finny",
+  "team-neusta",
+  "ventry",
+  "homelab",
+] as const;
+
+export type OrganizationId = (typeof ORGANIZATION_IDS)[number];
+
+export const EXPERIENCE_IDS = [
+  "building-finny",
+  "team-neusta-apprenticeship",
+  "built-ventry",
+  "homelab",
+] as const;
+
+export type ExperienceId = (typeof EXPERIENCE_IDS)[number];

--- a/src/data/technologies.ts
+++ b/src/data/technologies.ts
@@ -30,85 +30,178 @@ import vueLogo from "../assets/logos/vuedotjs.svg";
 import windowsLogo from "../assets/logos/windows11.svg";
 
 export type Technology = {
+  id: TechnologyId;
   name: string;
   logo: SvgComponent & ImageMetadata;
   href: string;
   darkModeLight?: boolean;
 };
 
+export type TechnologyId =
+  | "angular"
+  | "astro"
+  | "bun"
+  | "claude"
+  | "cloudflare"
+  | "codex"
+  | "cursor"
+  | "docker"
+  | "git"
+  | "gitea"
+  | "github"
+  | "gitlab"
+  | "linux"
+  | "macos"
+  | "nextjs"
+  | "gemini"
+  | "perplexity"
+  | "php"
+  | "phpstorm"
+  | "proxmox"
+  | "react"
+  | "symfony"
+  | "tailwindcss"
+  | "typescript"
+  | "typo3"
+  | "vscode"
+  | "vue"
+  | "windows";
+
 export const TECHNOLOGIES: Technology[] = [
-  { name: "PHP", logo: phpLogo, href: "https://www.php.net/" },
+  { id: "php", name: "PHP", logo: phpLogo, href: "https://www.php.net/" },
   {
+    id: "typescript",
     name: "TypeScript",
     logo: typescriptLogo,
     href: "https://www.typescriptlang.org/",
   },
-  { name: "React", logo: reactLogo, href: "https://react.dev/" },
+  { id: "react", name: "React", logo: reactLogo, href: "https://react.dev/" },
   {
+    id: "nextjs",
     name: "Next.js",
     logo: nextLogo,
     href: "https://nextjs.org/",
     darkModeLight: true,
   },
-  { name: "TYPO3", logo: typo3Logo, href: "https://typo3.org/" },
-  { name: "Angular", logo: angularLogo, href: "https://angular.dev/" },
-  { name: "Vue", logo: vueLogo, href: "https://vuejs.org/" },
+  { id: "typo3", name: "TYPO3", logo: typo3Logo, href: "https://typo3.org/" },
   {
+    id: "angular",
+    name: "Angular",
+    logo: angularLogo,
+    href: "https://angular.dev/",
+  },
+  { id: "vue", name: "Vue", logo: vueLogo, href: "https://vuejs.org/" },
+  {
+    id: "github",
     name: "GitHub",
     logo: githubLogo,
     href: "https://github.com/",
     darkModeLight: true,
   },
-  { name: "GitLab", logo: gitlabLogo, href: "https://gitlab.com/" },
-  { name: "Gitea", logo: giteaLogo, href: "https://about.gitea.com/" },
-  { name: "Docker", logo: dockerLogo, href: "https://www.docker.com/" },
-  { name: "Proxmox", logo: proxmoxLogo, href: "https://www.proxmox.com/" },
-  { name: "Linux", logo: linuxLogo, href: "https://www.linux.org/" },
   {
+    id: "gitlab",
+    name: "GitLab",
+    logo: gitlabLogo,
+    href: "https://gitlab.com/",
+  },
+  {
+    id: "gitea",
+    name: "Gitea",
+    logo: giteaLogo,
+    href: "https://about.gitea.com/",
+  },
+  {
+    id: "docker",
+    name: "Docker",
+    logo: dockerLogo,
+    href: "https://www.docker.com/",
+  },
+  {
+    id: "proxmox",
+    name: "Proxmox",
+    logo: proxmoxLogo,
+    href: "https://www.proxmox.com/",
+  },
+  {
+    id: "linux",
+    name: "Linux",
+    logo: linuxLogo,
+    href: "https://www.linux.org/",
+  },
+  {
+    id: "macos",
     name: "macOS",
     logo: appleLogo,
     href: "https://www.apple.com/macos/",
     darkModeLight: true,
   },
-  { name: "Astro", logo: astroLogo, href: "https://astro.build/" },
+  { id: "astro", name: "Astro", logo: astroLogo, href: "https://astro.build/" },
   {
+    id: "cloudflare",
     name: "Cloudflare",
     logo: cloudflareLogo,
     href: "https://www.cloudflare.com/",
   },
-  { name: "Bun", logo: bunLogo, href: "https://bun.sh/", darkModeLight: true },
-  { name: "Claude", logo: claudeLogo, href: "https://claude.ai/" },
   {
+    id: "bun",
+    name: "Bun",
+    logo: bunLogo,
+    href: "https://bun.sh/",
+    darkModeLight: true,
+  },
+  {
+    id: "claude",
+    name: "Claude",
+    logo: claudeLogo,
+    href: "https://claude.ai/",
+  },
+  {
+    id: "codex",
     name: "Codex",
     logo: openaiLogo,
     href: "https://openai.com/codex",
     darkModeLight: true,
   },
   {
+    id: "cursor",
     name: "Cursor",
     logo: cursorLogo,
     href: "https://cursor.com/",
     darkModeLight: true,
   },
-  { name: "Gemini", logo: geminiLogo, href: "https://gemini.google.com/" },
   {
+    id: "gemini",
+    name: "Gemini",
+    logo: geminiLogo,
+    href: "https://gemini.google.com/",
+  },
+  {
+    id: "perplexity",
     name: "Perplexity",
     logo: perplexityLogo,
     href: "https://www.perplexity.ai/",
   },
-  { name: "VS Code", logo: vscodeLogo, href: "https://code.visualstudio.com/" },
   {
+    id: "vscode",
+    name: "VS Code",
+    logo: vscodeLogo,
+    href: "https://code.visualstudio.com/",
+  },
+  {
+    id: "phpstorm",
     name: "PhpStorm",
     logo: phpstormLogo,
     href: "https://www.jetbrains.com/phpstorm/",
     darkModeLight: true,
   },
   {
+    id: "windows",
     name: "Windows",
     logo: windowsLogo,
     href: "https://www.microsoft.com/windows",
   },
   {
+    id: "tailwindcss",
     name: "Tailwind CSS",
     logo: tailwindLogo,
     href: "https://tailwindcss.com/",
@@ -117,10 +210,16 @@ export const TECHNOLOGIES: Technology[] = [
 
 export const EXPERIENCE_ONLY_TECHNOLOGIES: Technology[] = [
   {
+    id: "symfony",
     name: "Symfony",
     logo: symfonyLogo,
     href: "https://symfony.com/",
     darkModeLight: true,
   },
-  { name: "Git", logo: gitLogo, href: "https://git-scm.com/" },
+  { id: "git", name: "Git", logo: gitLogo, href: "https://git-scm.com/" },
+];
+
+export const ALL_TECHNOLOGIES = [
+  ...TECHNOLOGIES,
+  ...EXPERIENCE_ONLY_TECHNOLOGIES,
 ];

--- a/src/lib/content-validation.test.ts
+++ b/src/lib/content-validation.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { validatePortfolioContent } from "./content-validation";
+
+const validTranslation = () => ({
+  portfolio: {
+    experience: {
+      items: [
+        {
+          id: "building-finny",
+          organizationId: "finny",
+          technologies: ["typescript", "react", "nextjs"],
+        },
+        {
+          id: "team-neusta-apprenticeship",
+          organizationId: "team-neusta",
+          technologies: ["php", "symfony"],
+        },
+        {
+          id: "built-ventry",
+          organizationId: "ventry",
+          technologies: ["typescript", "nextjs"],
+        },
+        {
+          id: "homelab",
+          organizationId: "homelab",
+          technologies: ["proxmox", "linux", "windows"],
+        },
+      ],
+    },
+    finny: { id: "finny" },
+    ventry: { id: "ventry" },
+  },
+});
+
+describe("validatePortfolioContent", () => {
+  test("accepts complete content keyed by stable IDs", () => {
+    expect(() =>
+      validatePortfolioContent({
+        en: validTranslation(),
+        de: validTranslation(),
+      }),
+    ).not.toThrow();
+  });
+
+  test("reports missing entries and invalid references with their locale", () => {
+    const invalid = validTranslation();
+    invalid.portfolio.experience.items.pop();
+    invalid.portfolio.experience.items[0].technologies.push("renamed-label");
+    invalid.portfolio.ventry.id = "renamed-project";
+    expect(() => validatePortfolioContent({ en: invalid })).toThrow(
+      /en experience entries is missing: homelab.*unknown technology 'renamed-label'.*en project entries is missing: ventry.*unknown IDs: renamed-project/s,
+    );
+  });
+});

--- a/src/lib/content-validation.ts
+++ b/src/lib/content-validation.ts
@@ -1,0 +1,91 @@
+import { EXPERIENCE_IDS, ORGANIZATION_IDS, PROJECTS } from "../data/portfolio";
+import { ALL_TECHNOLOGIES } from "../data/technologies";
+
+type TranslationContent = Record<
+  string,
+  {
+    portfolio: {
+      experience: {
+        items: Array<{
+          id: string;
+          organizationId: string;
+          technologies: string[];
+        }>;
+      };
+      finny: { id: string };
+      ventry: { id: string };
+    };
+  }
+>;
+
+const duplicates = (values: string[]): string[] =>
+  values.filter((value, index) => values.indexOf(value) !== index);
+
+const compareIds = (
+  actual: string[],
+  expected: readonly string[],
+  label: string,
+  errors: string[],
+): void => {
+  const missing = expected.filter((id) => !actual.includes(id));
+  const unexpected = actual.filter((id) => !expected.includes(id));
+  if (missing.length) errors.push(`${label} is missing: ${missing.join(", ")}`);
+  if (unexpected.length)
+    errors.push(`${label} contains unknown IDs: ${unexpected.join(", ")}`);
+  const repeated = [...new Set(duplicates(actual))];
+  if (repeated.length)
+    errors.push(`${label} contains duplicate IDs: ${repeated.join(", ")}`);
+};
+
+export const validatePortfolioContent = (
+  translations: TranslationContent,
+): void => {
+  const errors: string[] = [];
+  const technologyIds = ALL_TECHNOLOGIES.map(({ id }) => id);
+  const technologyIdSet = new Set<string>(technologyIds);
+  const organizationIdSet = new Set<string>(ORGANIZATION_IDS);
+  compareIds(
+    technologyIds,
+    [...new Set(technologyIds)],
+    "technology catalog",
+    errors,
+  );
+
+  Object.entries(translations).forEach(([locale, strings]) => {
+    const portfolio = strings.portfolio;
+    const experienceIds = portfolio.experience.items.map(({ id }) => id);
+    compareIds(
+      experienceIds,
+      EXPERIENCE_IDS,
+      `${locale} experience entries`,
+      errors,
+    );
+
+    portfolio.experience.items.forEach((entry) => {
+      if (!organizationIdSet.has(entry.organizationId)) {
+        errors.push(
+          `${locale} experience '${entry.id}' references unknown organization '${entry.organizationId}'`,
+        );
+      }
+      entry.technologies.forEach((technologyId) => {
+        if (!technologyIdSet.has(technologyId)) {
+          errors.push(
+            `${locale} experience '${entry.id}' references unknown technology '${technologyId}'`,
+          );
+        }
+      });
+    });
+
+    const projectIds = [portfolio.finny.id, portfolio.ventry.id];
+    compareIds(
+      projectIds,
+      Object.keys(PROJECTS),
+      `${locale} project entries`,
+      errors,
+    );
+  });
+
+  if (errors.length > 0) {
+    throw new Error(`Invalid portfolio content:\n- ${errors.join("\n- ")}`);
+  }
+};

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,8 +1,13 @@
 // Bilingual content + locale detection from Accept-Language header.
 
-import { TECHNOLOGIES } from "../data/technologies";
-import type { Technology } from "../data/technologies";
+import type {
+  ExperienceId,
+  OrganizationId,
+  ProjectId,
+} from "../data/portfolio";
+import type { TechnologyId } from "../data/technologies";
 import type { Locale } from "./locale";
+import { validatePortfolioContent } from "./content-validation";
 export { detectLocale } from "./locale";
 export type { Locale } from "./locale";
 
@@ -11,6 +16,15 @@ interface Strings {
   meta: {
     imageAlt: string;
     jobTitle: string;
+  };
+  privacyConsent: {
+    title: string;
+    text: string;
+    accept: string;
+    reject: string;
+    settings: string;
+    settingsShort: string;
+    privacy: string;
   };
   portfolio: {
     subtitle: (age: number) => string;
@@ -33,13 +47,14 @@ interface Strings {
       mobileViewMore: string;
       mobileViewLess: string;
       visitLabel: (name: string) => string;
-      items: Technology[];
     };
     experience: {
       heading: string;
       items: {
+        id: ExperienceId;
         period: string;
         title: string;
+        organizationId: OrganizationId;
         organization: string;
         location: string;
         secondary?: {
@@ -47,7 +62,7 @@ interface Strings {
           title: string;
         };
         bullets: string[];
-        technologies: string[];
+        technologies: TechnologyId[];
       }[];
     };
     projects: string;
@@ -77,6 +92,7 @@ interface Strings {
       emailCopied: string;
     };
     finny: {
+      id: Extract<ProjectId, "finny">;
       linkAria: string;
       previewAria: string;
       receiptTitle: string;
@@ -97,6 +113,7 @@ interface Strings {
       cta: { prefix: string; label: string };
     };
     ventry: {
+      id: Extract<ProjectId, "ventry">;
       linkAria: string;
       previewAria: string;
       panelTitle: string;
@@ -118,6 +135,15 @@ const en: Strings = {
   meta: {
     imageAlt: "Jan-Marlon Leibl's portfolio",
     jobTitle: "Software Developer",
+  },
+  privacyConsent: {
+    title: "Privacy settings",
+    text: "With your permission, I use PostHog to see which parts of the site people use and where technical errors occur.",
+    accept: "Allow analytics",
+    reject: "Necessary cookies only",
+    settings: "Privacy settings",
+    settingsShort: "Privacy",
+    privacy: "Privacy policy",
   },
   portfolio: {
     subtitle: (age) => `${age}, software developer from Bremen`,
@@ -147,24 +173,27 @@ const en: Strings = {
       mobileViewMore: "Show more",
       mobileViewLess: "Show fewer",
       visitLabel: (name) => `Visit ${name}`,
-      items: TECHNOLOGIES,
     },
     experience: {
       heading: "Experience",
       items: [
         {
+          id: "building-finny",
           period: "Since 2026",
           title: "Building",
+          organizationId: "finny",
           organization: "Finny",
           location: "Bremen",
           bullets: [
             "I'm building Finny to keep receipts and purchase details in one place, with a reminder before each warranty expires.",
           ],
-          technologies: ["TypeScript", "React", "Next.js"],
+          technologies: ["typescript", "react", "nextjs"],
         },
         {
+          id: "team-neusta-apprenticeship",
           period: "2023 to 2026",
           title: "Software development apprenticeship at",
+          organizationId: "team-neusta",
           organization: "team neusta",
           location: "Bremen",
           secondary: {
@@ -174,27 +203,31 @@ const en: Strings = {
           bullets: [
             "I worked on client projects using PHP, TypeScript and TYPO3.",
           ],
-          technologies: ["PHP", "Symfony", "TypeScript", "TYPO3", "Git"],
+          technologies: ["php", "symfony", "typescript", "typo3", "git"],
         },
         {
+          id: "built-ventry",
           period: "2023 to 2024",
           title: "Built",
+          organizationId: "ventry",
           organization: "Ventry",
           location: "Bremen",
           bullets: [
             "I built Ventry because I wanted a simple way to share files through links that expire on their own.",
           ],
-          technologies: ["TypeScript", "Next.js"],
+          technologies: ["typescript", "nextjs"],
         },
         {
+          id: "homelab",
           period: "Personal",
           title: "Running my",
+          organizationId: "homelab",
           organization: "homelab",
           location: "Bremen",
           bullets: [
             "I keep a Proxmox node and my home network running, upgrade hardware and chase down whatever broke this time.",
           ],
-          technologies: ["Proxmox", "Linux", "Windows"],
+          technologies: ["proxmox", "linux", "windows"],
         },
       ],
     },
@@ -225,6 +258,7 @@ const en: Strings = {
       emailCopied: "Copied",
     },
     finny: {
+      id: "finny",
       linkAria: "Open Finny",
       previewAria: "Preview of Finny",
       receiptTitle: "RECEIPT",
@@ -245,6 +279,7 @@ const en: Strings = {
       cta: { prefix: "", label: "Open Finny ↗" },
     },
     ventry: {
+      id: "ventry",
       linkAria: "Open Ventry",
       previewAria: "Preview of Ventry",
       panelTitle: "RECENT UPLOADS",
@@ -268,6 +303,15 @@ const de: Strings = {
   meta: {
     imageAlt: "Portfolio von Jan-Marlon Leibl",
     jobTitle: "Softwareentwickler",
+  },
+  privacyConsent: {
+    title: "Datenschutz-Einstellungen",
+    text: "Mit Ihrer Zustimmung lade ich PostHog. So sehe ich, welche Bereiche genutzt werden und wo technische Fehler auftreten.",
+    accept: "Analyse erlauben",
+    reject: "Nur notwendige Cookies",
+    settings: "Datenschutz-Einstellungen",
+    settingsShort: "Datenschutz",
+    privacy: "Datenschutzerklärung",
   },
   portfolio: {
     subtitle: (age) => `${age}, Softwareentwickler aus Bremen`,
@@ -297,24 +341,27 @@ const de: Strings = {
       mobileViewMore: "Mehr zeigen",
       mobileViewLess: "Weniger zeigen",
       visitLabel: (name) => `${name} besuchen`,
-      items: TECHNOLOGIES,
     },
     experience: {
       heading: "Erfahrung",
       items: [
         {
+          id: "building-finny",
           period: "Seit 2026",
           title: "Ich entwickle",
+          organizationId: "finny",
           organization: "Finny",
           location: "Bremen",
           bullets: [
             "Ich baue Finny, damit Belege und Kaufdetails nicht mehr an verschiedenen Orten liegen. Vor Ablauf einer Garantie gibt die App rechtzeitig Bescheid.",
           ],
-          technologies: ["TypeScript", "React", "Next.js"],
+          technologies: ["typescript", "react", "nextjs"],
         },
         {
+          id: "team-neusta-apprenticeship",
           period: "2023 bis 2026",
           title: "Ausbildung zum Softwareentwickler bei",
+          organizationId: "team-neusta",
           organization: "team neusta",
           location: "Bremen",
           secondary: {
@@ -324,27 +371,31 @@ const de: Strings = {
           bullets: [
             "Bei Kundenprojekten habe ich hauptsächlich mit PHP, TypeScript und TYPO3 gearbeitet.",
           ],
-          technologies: ["PHP", "Symfony", "TypeScript", "TYPO3", "Git"],
+          technologies: ["php", "symfony", "typescript", "typo3", "git"],
         },
         {
+          id: "built-ventry",
           period: "2023 bis 2024",
           title: "Entwickelt",
+          organizationId: "ventry",
           organization: "Ventry",
           location: "Bremen",
           bullets: [
             "Ventry entstand, weil ich Dateien unkompliziert über Links teilen wollte, die von selbst ablaufen.",
           ],
-          technologies: ["TypeScript", "Next.js"],
+          technologies: ["typescript", "nextjs"],
         },
         {
+          id: "homelab",
           period: "Privat",
           title: "Betreibe mein",
+          organizationId: "homelab",
           organization: "Homelab",
           location: "Bremen",
           bullets: [
             "Ich halte einen Proxmox-Node und mein Heimnetz am Laufen, rüste Hardware auf und suche heraus, was diesmal kaputtgegangen ist.",
           ],
-          technologies: ["Proxmox", "Linux", "Windows"],
+          technologies: ["proxmox", "linux", "windows"],
         },
       ],
     },
@@ -375,6 +426,7 @@ const de: Strings = {
       emailCopied: "Kopiert",
     },
     finny: {
+      id: "finny",
       linkAria: "Finny öffnen",
       previewAria: "Vorschau von Finny",
       receiptTitle: "BELEG",
@@ -395,6 +447,7 @@ const de: Strings = {
       cta: { prefix: "", label: "Finny öffnen ↗" },
     },
     ventry: {
+      id: "ventry",
       linkAria: "Ventry öffnen",
       previewAria: "Vorschau von Ventry",
       panelTitle: "LETZTE DATEIEN",
@@ -414,6 +467,7 @@ const de: Strings = {
 };
 
 const dict = { en, de };
+validatePortfolioContent(dict);
 
 export function tr(locale: Locale): Strings {
   return dict[locale];

--- a/src/lib/portfolio.ts
+++ b/src/lib/portfolio.ts
@@ -1,5 +1,5 @@
-import { EXPERIENCE_ONLY_TECHNOLOGIES } from "../data/technologies";
-import type { Technology } from "../data/technologies";
+import { ALL_TECHNOLOGIES } from "../data/technologies";
+import type { TechnologyId } from "../data/technologies";
 
 export type StickerPlacement = {
   side: "left" | "right";
@@ -9,15 +9,15 @@ export type StickerPlacement = {
   rotation: number;
 };
 
-const FEATURED_MOBILE_TECHNOLOGIES = [
-  "PHP",
-  "TypeScript",
-  "React",
-  "Next.js",
-  "TYPO3",
-  "Symfony",
-  "Git",
-  "Docker",
+const FEATURED_MOBILE_TECHNOLOGIES: readonly TechnologyId[] = [
+  "php",
+  "typescript",
+  "react",
+  "nextjs",
+  "typo3",
+  "symfony",
+  "git",
+  "docker",
 ];
 
 const STICKER_HORIZONTAL_BANDS = [
@@ -26,25 +26,20 @@ const STICKER_HORIZONTAL_BANDS = [
   [72, 94],
 ] as const;
 
-export function createTechnologyCollections(technologies: Technology[]) {
-  const all = [...technologies, ...EXPERIENCE_ONLY_TECHNOLOGIES];
-  const byName = new Map(
-    all.map((technology) => [technology.name, technology]),
+export function createTechnologyCollections() {
+  const byId = new Map(
+    ALL_TECHNOLOGIES.map((technology) => [technology.id, technology]),
   );
-  const featured = FEATURED_MOBILE_TECHNOLOGIES.map((name) =>
-    byName.get(name),
-  ).filter((technology): technology is Technology => Boolean(technology));
+  const featured = FEATURED_MOBILE_TECHNOLOGIES.map((id) =>
+    byId.get(id),
+  ).filter((technology) => technology !== undefined);
 
   return {
-    all,
+    all: ALL_TECHNOLOGIES,
     featured,
-    additional: all.filter(
-      (technology) => !FEATURED_MOBILE_TECHNOLOGIES.includes(technology.name),
+    additional: ALL_TECHNOLOGIES.filter(
+      (technology) => !FEATURED_MOBILE_TECHNOLOGIES.includes(technology.id),
     ),
-    find: (names: string[]) =>
-      names
-        .map((name) => byName.get(name))
-        .filter((technology): technology is Technology => Boolean(technology)),
   };
 }
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,6 +10,7 @@ import PortfolioFooter from "../components/home/PortfolioFooter.astro";
 import ProfileSection from "../components/home/ProfileSection.astro";
 import ProjectsSection from "../components/home/ProjectsSection.astro";
 import TechnologiesSection from "../components/home/TechnologiesSection.astro";
+import { TECHNOLOGIES } from "../data/technologies";
 import Layout from "../layouts/Layout.astro";
 import { buildActivity, fetchGithubContributions } from "../lib/github";
 import { detectLocale, tr } from "../lib/i18n";
@@ -25,7 +26,7 @@ const currentAge = ageYears();
 const githubDays = await fetchGithubContributions((task) =>
   Astro.locals.cfContext.waitUntil(task),
 );
-const technologies = createTechnologyCollections(copy.tech.items);
+const technologies = createTechnologyCollections();
 const activity = buildActivity(githubDays, locale, copy.activity);
 const activityTotal = activity.reduce((total, day) => total + day.count, 0);
 const activityAriaLabel = `${copy.activity.aria}: ${new Intl.NumberFormat(locale).format(activityTotal)} ${activityTotal === 1 ? copy.activity.contribution : copy.activity.contributions}`;
@@ -40,8 +41,8 @@ const linkedinUrl =
     <EdgeBlur />
     <EdgeBlur edge="bottom" />
     <PortfolioChrome
-      technologies={copy.tech.items}
-      stickerLayout={createStickerLayout(copy.tech.items.length)}
+      technologies={TECHNOLOGIES}
+      stickerLayout={createStickerLayout(TECHNOLOGIES.length)}
       labels={{
         ...copy.avatar,
         technologies: copy.tech.aria,


### PR DESCRIPTION
Closes #15

## Summary
- key technologies, projects, organizations, and experience entries by typed stable IDs
- remove behavioral and asset lookups based on localized display names
- validate localized project and technology references during build with actionable errors
- centralize cookie-consent translations in the typed i18n model
- enforce shared dates, headings, and policy links across rendered and Markdown privacy content

## Verification
- `bun run ci`
- 22 unit tests, including invalid content reference coverage