### PR TITLE
chore: add repository quality gates

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,42 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "23 4 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze JavaScript and TypeScript
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      actions: read
+      contents: read
+      packages: read
+      security-events: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: javascript-typescript
+          build-mode: none
+
+      - name: Analyze source
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:javascript-typescript"

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,49 @@
+name: Lighthouse
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: lighthouse-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build production Worker
+        run: bun run build
+
+      - name: Enforce Lighthouse budgets
+        run: bun run lighthouse:ci
+        env:
+          CHROME_PATH: /usr/bin/google-chrome
+
+      - name: Upload Lighthouse reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: lighthouse-reports
+          path: .lighthouseci/
+          include-hidden-files: true
+          if-no-files-found: warn
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ pnpm-lock.yaml
 coverage/
 .eslintcache
 .impeccable/
+.lighthouseci/
 
 # jetbrains setting folder
 .idea/

--- a/.lighthouserc.cjs
+++ b/.lighthouserc.cjs
@@ -1,0 +1,61 @@
+const chromeProfileDirectory = process.env.LIGHTHOUSE_PROFILE_DIRECTORY;
+
+if (!chromeProfileDirectory) {
+  throw new Error("Run Lighthouse CI through `bun run lighthouse:ci`.");
+}
+
+module.exports = {
+  ci: {
+    collect: {
+      url: [
+        "http://127.0.0.1:4327/",
+        "http://127.0.0.1:4327/de",
+        "http://127.0.0.1:4327/en",
+        "http://127.0.0.1:4327/privacy",
+      ],
+      numberOfRuns: 3,
+      startServerCommand:
+        "bunx wrangler dev --config dist/server/wrangler.json --ip 127.0.0.1 --port 4327 --show-interactive-dev-session false",
+      startServerReadyPattern: "Ready on http://127.0.0.1:4327",
+      startServerReadyTimeout: 30_000,
+      settings: {
+        preset: "desktop",
+        chromeFlags: `--headless=new --no-sandbox --user-data-dir="${chromeProfileDirectory}"`,
+        onlyCategories: [
+          "performance",
+          "accessibility",
+          "best-practices",
+          "seo",
+        ],
+      },
+    },
+    assert: {
+      assertions: {
+        "categories:performance": ["error", { minScore: 0.95 }],
+        "categories:accessibility": ["error", { minScore: 0.95 }],
+        "categories:best-practices": ["error", { minScore: 1 }],
+        "categories:seo": ["error", { minScore: 0.9 }],
+        "first-contentful-paint": [
+          "error",
+          { maxNumericValue: 1_800, aggregationMethod: "median-run" },
+        ],
+        "largest-contentful-paint": [
+          "error",
+          { maxNumericValue: 2_500, aggregationMethod: "median-run" },
+        ],
+        "cumulative-layout-shift": [
+          "error",
+          { maxNumericValue: 0.1, aggregationMethod: "median-run" },
+        ],
+        "total-blocking-time": [
+          "error",
+          { maxNumericValue: 200, aggregationMethod: "median-run" },
+        ],
+        "speed-index": [
+          "error",
+          { maxNumericValue: 3_400, aggregationMethod: "median-run" },
+        ],
+      },
+    },
+  },
+};

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,9 @@ performance improvements are welcome.
 3. Make a focused change.
 4. Add or update tests when behavior changes.
 5. Run `bun run ci`.
-6. Open a pull request with a concise explanation and screenshots for visual changes.
+6. For changes that can affect rendering or page weight, also run
+   `bun run lighthouse:ci` after `bun run build`.
+7. Open a pull request with a concise explanation and screenshots for visual changes.
 
 Do not commit `.env`, credentials, analytics secrets, build output, or editor
 configuration.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,7 +14,7 @@ export default [
   })),
   ...astro.configs.recommended,
   {
-    files: ["**/*.{js,mjs,ts,astro}"],
+    files: ["**/*.{cjs,js,mjs,ts,astro}"],
     languageOptions: {
       globals: {
         ...globals.browser,

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "check:deploy": "wrangler deploy --config dist/server/wrangler.json --dry-run",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "lighthouse:ci": "bun scripts/lighthouse-ci.mjs",
     "lint": "eslint . --max-warnings=0",
     "preview": "astro preview",
     "test": "bun test",

--- a/scripts/lighthouse-ci.mjs
+++ b/scripts/lighthouse-ci.mjs
@@ -1,0 +1,31 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const chromeProfileDirectory = await mkdtemp(
+  join(tmpdir(), "itsjan-lighthouse-"),
+);
+
+try {
+  const exitCode = await new Promise((resolve, reject) => {
+    const lighthouse = spawn(
+      process.execPath,
+      ["x", "@lhci/cli@0.15.1", "autorun"],
+      {
+        env: {
+          ...process.env,
+          LIGHTHOUSE_PROFILE_DIRECTORY: chromeProfileDirectory,
+        },
+        stdio: "inherit",
+      },
+    );
+
+    lighthouse.once("error", reject);
+    lighthouse.once("close", (code) => resolve(code ?? 1));
+  });
+
+  if (exitCode !== 0) process.exitCode = exitCode;
+} finally {
+  await rm(chromeProfileDirectory, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary

- add weekly and pull-request CodeQL analysis for JavaScript and TypeScript
- enforce measured Lighthouse budgets across `/`, `/de`, `/en`, and `/privacy`
- upload Lighthouse reports and document the local validation command
- isolate and clean up Chrome profiles so local Lighthouse runs leave no repository artifacts

## Validation

- [x] `bun run ci`
- [x] `bun run check`
- [x] `bun audit` (0 vulnerabilities)
- [x] `CHROME_PATH=/usr/bin/google-chrome bun run lighthouse:ci` (12/12 runs pass)
- [x] Playwright browser smoke test (all interactions pass, no console/runtime errors)

Measured local range: performance 99–100, accessibility 96–99, best practices 100, SEO 92; max LCP 925 ms, max CLS 0.0051, TBT 0 ms.

Closes #24