### PR TITLE
fix: canonicalize trailing-slash URLs

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -13,6 +13,7 @@ const optimizeDepsExclude = [
 export default defineConfig({
   site: "https://itsjan.dev",
   output: "server",
+  trailingSlash: "never",
   adapter: cloudflare(),
   integrations: [sitemap()],
   vite: {

--- a/scripts/browser-smoke.mjs
+++ b/scripts/browser-smoke.mjs
@@ -89,6 +89,28 @@ try {
     "max-age=31536000",
   );
 
+  const trailingSlashResponse = await fetch(`${baseUrl}/en/?source=smoke`, {
+    redirect: "manual",
+  });
+  assert.ok([301, 308].includes(trailingSlashResponse.status));
+  assert.equal(
+    new URL(trailingSlashResponse.headers.get("location"), baseUrl).href,
+    `${baseUrl}/en?source=smoke`,
+  );
+
+  const sitemapResponse = await fetch(`${baseUrl}/sitemap-0.xml`);
+  assert.equal(sitemapResponse.status, 200);
+  const sitemap = await sitemapResponse.text();
+  const sitemapUrls = [...sitemap.matchAll(/<loc>([^<]+)<\/loc>/g)].map(
+    ([, url]) => url,
+  );
+  assert.deepEqual(sitemapUrls, [
+    "https://itsjan.dev",
+    "https://itsjan.dev/de",
+    "https://itsjan.dev/en",
+    "https://itsjan.dev/privacy",
+  ]);
+
   const staticImageResponse = await fetch(`${baseUrl}/favicon.png`);
   assert.equal(
     staticImageResponse.headers.get("cache-control"),

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -21,6 +21,25 @@ describe("acceptsMarkdown", () => {
 });
 
 describe("contentResponseFor", () => {
+  test("redirects trailing slashes to the canonical URL in one hop", async () => {
+    const response = await contentResponseFor(
+      new Request("https://preview.example/en/?source=test"),
+    );
+
+    expect(response?.status).toBe(308);
+    expect(response?.headers.get("Location")).toBe(
+      "https://preview.example/en?source=test",
+    );
+  });
+
+  test("keeps the root URL unchanged", async () => {
+    const response = await contentResponseFor(
+      new Request("https://preview.example/"),
+    );
+
+    expect(response).toBeUndefined();
+  });
+
   test("negotiates localized Markdown and language-aware Vary headers", async () => {
     const response = await contentResponseFor(
       new Request("https://preview.example/", {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -189,7 +189,19 @@ export function applyResponseHeaders(
 export async function contentResponseFor(
   request: Request,
 ): Promise<Response | undefined> {
-  const pathname = new URL(request.url).pathname.replace(/\/$/, "") || "/";
+  const requestUrl = new URL(request.url);
+  const pathname = requestUrl.pathname.replace(/\/+$/, "") || "/";
+
+  if (requestUrl.pathname !== pathname) {
+    requestUrl.pathname = pathname;
+    return applyResponseHeaders(
+      new Response(null, {
+        status: 308,
+        headers: { Location: requestUrl.href },
+      }),
+    );
+  }
+
   const markdown = markdownFor(request, pathname);
   const textResource = textResources[pathname];
 


### PR DESCRIPTION
## Summary

- enforce slashless Astro routes and sitemap URLs
- permanently redirect trailing-slash requests while preserving query strings
- cover middleware behavior, runtime redirects, and generated sitemap output

## Validation

- `bun run ci`
- `CHROME_PATH=/usr/bin/google-chrome bun run lighthouse:ci`

Closes #37
