### PR TITLE
fix: stabilize the x-default homepage

### DIFF
--- a/scripts/browser-smoke.mjs
+++ b/scripts/browser-smoke.mjs
@@ -125,8 +125,21 @@ try {
   });
   assert.equal(markdownResponse.status, 200);
   assert.match(markdownResponse.headers.get("content-type") ?? "", /markdown/);
-  assert.match(markdownResponse.headers.get("vary") ?? "", /Accept-Language/);
-  assert.match(await markdownResponse.text(), /Softwareentwickler/);
+  assert.doesNotMatch(
+    markdownResponse.headers.get("vary") ?? "",
+    /Accept-Language/,
+  );
+  assert.match(await markdownResponse.text(), /software developer/);
+
+  const germanPreferenceResponse = await fetch(baseUrl, {
+    headers: { "Accept-Language": "de-DE,de;q=0.9" },
+  });
+  const germanPreferenceHtml = await germanPreferenceResponse.text();
+  assert.match(germanPreferenceHtml, /<html lang="en"/);
+  assert.match(
+    germanPreferenceHtml,
+    /Jan-Marlon Leibl · Software developer from Bremen/,
+  );
 
   browser = await chromium.launch({
     executablePath: browserExecutable,

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -50,7 +50,6 @@ const markdownPath = isPortfolioPage
     : undefined;
 const markdownUrl = markdownPath ? `${SITE_ORIGIN}${markdownPath}` : undefined;
 
-Astro.response.headers.set("Vary", "Accept-Language");
 if (requestUrl.pathname === "/" || requestUrl.pathname === "") {
   Astro.response.headers.set("Link", '</llms.txt>; rel="describedby"');
 }

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,4 +1,4 @@
-// Bilingual content + locale detection from Accept-Language header.
+// Bilingual content keyed by explicit locale routes.
 
 import type {
   ExperienceId,

--- a/src/lib/locale.test.ts
+++ b/src/lib/locale.test.ts
@@ -12,13 +12,14 @@ describe("detectLocale", () => {
     expect(detectLocale(request("/en", "de-DE"))).toBe("en");
   });
 
-  test("respects quality values and ignores rejected languages", () => {
-    expect(detectLocale(request("/", "de-DE;q=0.4, en-US;q=0.9"))).toBe("en");
-    expect(detectLocale(request("/", "de;q=0"))).toBe("en");
+  test("keeps the x-default route English regardless of Accept-Language", () => {
+    expect(detectLocale(request("/", "de-DE,de;q=0.9"))).toBe("en");
+    expect(detectLocale(request("/", "en-US;q=0.2,de;q=1"))).toBe("en");
   });
 
-  test("defaults to English for unsupported or missing languages", () => {
+  test("defaults unprefixed routes to English", () => {
     expect(detectLocale(request("/", "fr-FR"))).toBe("en");
     expect(detectLocale(request("/"))).toBe("en");
+    expect(detectLocale(request("/privacy", "de-DE"))).toBe("en");
   });
 });

--- a/src/lib/locale.ts
+++ b/src/lib/locale.ts
@@ -3,30 +3,5 @@ export type Locale = "en" | "de";
 export function detectLocale(request: Request): Locale {
   const pathLocale = new URL(request.url).pathname.split("/")[1];
   if (pathLocale === "de" || pathLocale === "en") return pathLocale;
-
-  const preferences = (request.headers.get("Accept-Language") ?? "")
-    .split(",")
-    .map((entry, index) => {
-      const [tag, ...parameters] = entry.trim().toLowerCase().split(";");
-      const qualityParameter = parameters.find((parameter) =>
-        parameter.trim().startsWith("q="),
-      );
-      const parsedQuality = qualityParameter
-        ? Number.parseFloat(qualityParameter.split("=", 2)[1])
-        : 1;
-      return {
-        tag,
-        quality: Number.isFinite(parsedQuality) ? parsedQuality : 0,
-        index,
-      };
-    })
-    .filter(({ quality }) => quality > 0)
-    .sort((a, b) => b.quality - a.quality || a.index - b.index);
-
-  for (const { tag } of preferences) {
-    if (tag === "de" || tag.startsWith("de-")) return "de";
-    if (tag === "en" || tag.startsWith("en-")) return "en";
-  }
-
   return "en";
 }

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -40,7 +40,7 @@ describe("contentResponseFor", () => {
     expect(response).toBeUndefined();
   });
 
-  test("negotiates localized Markdown and language-aware Vary headers", async () => {
+  test("keeps x-default Markdown stable across language preferences", async () => {
     const response = await contentResponseFor(
       new Request("https://preview.example/", {
         headers: {
@@ -54,9 +54,8 @@ describe("contentResponseFor", () => {
     expect(response?.headers.get("Content-Type")).toBe(
       "text/markdown; charset=utf-8",
     );
-    expect(response?.headers.get("Vary")).toContain("Accept");
-    expect(response?.headers.get("Vary")).toContain("Accept-Language");
-    expect(await response?.text()).toContain("Softwareentwickler");
+    expect(response?.headers.get("Vary")).toBe("Accept");
+    expect(await response?.text()).toContain("software developer");
   });
 
   test("serves explicit locale routes independently of Accept-Language", async () => {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -224,7 +224,6 @@ export async function contentResponseFor(
   if (acceptsMarkdown(request.headers.get("Accept")) && markdown) {
     return applyResponseHeaders(
       textResponse(request, markdown, "text/markdown; charset=utf-8"),
-      pathname === "/" || pathname === "/privacy",
     );
   }
 


### PR DESCRIPTION
## Summary

- make unprefixed routes deterministic English fallbacks
- keep `/en` and `/de` explicit and independent of request headers
- remove obsolete `Accept-Language` cache variation
- test HTML and Markdown responses across language preferences

## Validation

- `bun run ci`

Closes #35
