### PR TITLE
feat: publish stable localized privacy routes

### DIFF
--- a/.lighthouserc.cjs
+++ b/.lighthouserc.cjs
@@ -11,7 +11,8 @@ module.exports = {
         "http://127.0.0.1:4327/",
         "http://127.0.0.1:4327/de",
         "http://127.0.0.1:4327/en",
-        "http://127.0.0.1:4327/privacy",
+        "http://127.0.0.1:4327/en/privacy",
+        "http://127.0.0.1:4327/de/datenschutz",
       ],
       numberOfRuns: 3,
       startServerCommand:

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -15,7 +15,11 @@ export default defineConfig({
   output: "server",
   trailingSlash: "never",
   adapter: cloudflare(),
-  integrations: [sitemap()],
+  integrations: [
+    sitemap({
+      filter: (page) => new URL(page).pathname !== "/privacy",
+    }),
+  ],
   vite: {
     plugins: [tailwindcss()],
     optimizeDeps: {

--- a/scripts/browser-smoke.mjs
+++ b/scripts/browser-smoke.mjs
@@ -107,9 +107,39 @@ try {
   assert.deepEqual(sitemapUrls, [
     "https://itsjan.dev",
     "https://itsjan.dev/de",
+    "https://itsjan.dev/de/datenschutz",
     "https://itsjan.dev/en",
-    "https://itsjan.dev/privacy",
+    "https://itsjan.dev/en/privacy",
   ]);
+
+  const legacyPrivacyResponse = await fetch(`${baseUrl}/privacy`, {
+    redirect: "manual",
+  });
+  assert.equal(legacyPrivacyResponse.status, 308);
+  assert.equal(
+    new URL(legacyPrivacyResponse.headers.get("location"), baseUrl).href,
+    `${baseUrl}/en/privacy`,
+  );
+
+  for (const [path, language, canonical, alternate] of [
+    ["/en/privacy", "en", "/en/privacy", "/de/datenschutz"],
+    ["/de/datenschutz", "de", "/de/datenschutz", "/en/privacy"],
+  ]) {
+    const response = await fetch(`${baseUrl}${path}`);
+    const html = await response.text();
+    assert.equal(response.status, 200);
+    assert.match(html, new RegExp(`<html lang="${language}"`));
+    assert.match(
+      html,
+      new RegExp(`rel="canonical" href="https://itsjan.dev${canonical}"`),
+    );
+    assert.match(
+      html,
+      new RegExp(
+        `hreflang="${language === "en" ? "de" : "en"}" href="https://itsjan.dev${alternate}"`,
+      ),
+    );
+  }
 
   const staticImageResponse = await fetch(`${baseUrl}/favicon.png`);
   assert.equal(

--- a/src/components/CookieConsent.astro
+++ b/src/components/CookieConsent.astro
@@ -32,7 +32,7 @@ const copy = tr(locale).privacyConsent;
     <InteractiveLink
       variant="text"
       class="hero-project-link privacy-consent__link"
-      href="/privacy"
+      href={locale === "de" ? "/de/datenschutz" : "/en/privacy"}
     >
       <span>{copy.privacy}</span>
       <ArrowIcon />

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -6,6 +6,7 @@ import ConsoleEasterEgg from "../components/ConsoleEasterEgg.astro";
 import InteractionRuntime from "../components/InteractionRuntime.astro";
 import PostHog from "../components/posthog.astro";
 import { detectLocale, tr } from "../lib/i18n";
+import type { Locale } from "../lib/locale";
 import {
   CONTACT_EMAIL,
   OPEN_GRAPH_IMAGE_URL,
@@ -21,6 +22,8 @@ interface Props {
   title?: string;
   description?: string;
   noindex?: boolean;
+  alternatePaths?: Partial<Record<Locale | "x-default", string>>;
+  markdownPath?: string;
 }
 
 const props: Props = Astro.props;
@@ -41,14 +44,17 @@ const pathname = requestUrl.pathname.replace(/\/$/, "") || "/";
 const isPortfolioPage =
   pathname === "/" || pathname === "/de" || pathname === "/en";
 const url = new URL(pathname, SITE_ORIGIN).href;
-const markdownPath = isPortfolioPage
-  ? pathname === "/"
-    ? `/${locale}.md`
-    : `${pathname}.md`
-  : pathname === "/privacy"
-    ? `/privacy.${locale}.md`
-    : undefined;
+const markdownPath =
+  props.markdownPath ??
+  (isPortfolioPage
+    ? pathname === "/"
+      ? `/${locale}.md`
+      : `${pathname}.md`
+    : undefined);
 const markdownUrl = markdownPath ? `${SITE_ORIGIN}${markdownPath}` : undefined;
+const alternatePaths =
+  props.alternatePaths ??
+  (isPortfolioPage ? { en: "/en", de: "/de", "x-default": "/" } : undefined);
 
 if (requestUrl.pathname === "/" || requestUrl.pathname === "") {
   Astro.response.headers.set("Link", '</llms.txt>; rel="describedby"');
@@ -95,13 +101,14 @@ if (requestUrl.pathname === "/" || requestUrl.pathname === "") {
       )
     }
     {
-      isPortfolioPage && (
-        <>
-          <link rel="alternate" hreflang="en" href={`${SITE_ORIGIN}/en`} />
-          <link rel="alternate" hreflang="de" href={`${SITE_ORIGIN}/de`} />
-          <link rel="alternate" hreflang="x-default" href={SITE_ORIGIN} />
-        </>
-      )
+      alternatePaths &&
+        Object.entries(alternatePaths).map(([hreflang, path]) => (
+          <link
+            rel="alternate"
+            hreflang={hreflang}
+            href={new URL(path, SITE_ORIGIN).href}
+          />
+        ))
     }
     <link rel="icon" type="image/png" href="/favicon.png" />
     <link rel="apple-touch-icon" href="/jan-profile.jpg" />

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -40,6 +40,35 @@ describe("contentResponseFor", () => {
     expect(response).toBeUndefined();
   });
 
+  test("redirects the legacy privacy URL to the stable English route", async () => {
+    const response = await contentResponseFor(
+      new Request("https://preview.example/privacy?source=footer"),
+    );
+
+    expect(response?.status).toBe(308);
+    expect(response?.headers.get("Location")).toBe(
+      "https://preview.example/en/privacy?source=footer",
+    );
+  });
+
+  test("serves both localized privacy Markdown routes explicitly", async () => {
+    const english = await contentResponseFor(
+      new Request("https://preview.example/en/privacy", {
+        headers: { Accept: "text/markdown", "Accept-Language": "de" },
+      }),
+    );
+    const german = await contentResponseFor(
+      new Request("https://preview.example/de/datenschutz", {
+        headers: { Accept: "text/markdown", "Accept-Language": "en" },
+      }),
+    );
+
+    expect(await english?.text()).toContain("# Privacy policy");
+    expect(await german?.text()).toContain("# Datenschutzerklärung");
+    expect(english?.headers.get("Vary")).toBe("Accept");
+    expect(german?.headers.get("Vary")).toBe("Accept");
+  });
+
   test("keeps x-default Markdown stable across language preferences", async () => {
     const response = await contentResponseFor(
       new Request("https://preview.example/", {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -9,12 +9,17 @@ import llmsText from "./content/resources/llms.txt?raw";
 import privacyDeMarkdown from "./content/resources/privacy.de.md?raw";
 import privacyEnMarkdown from "./content/resources/privacy.en.md?raw";
 import profileSkillMarkdown from "./content/resources/skills/itsjan-profile/SKILL.md?raw";
-import { detectLocale } from "./lib/locale";
 import { SITE_ORIGIN } from "./lib/site";
 
 const markdownRoutes: Record<string, string> = {
   "/en": enMarkdown,
   "/de": deMarkdown,
+  "/en/privacy": privacyEnMarkdown,
+  "/de/datenschutz": privacyDeMarkdown,
+};
+
+const permanentRedirects: Record<string, string> = {
+  "/privacy": "/en/privacy",
 };
 
 const textResources: Record<string, { body: string; contentType: string }> = {
@@ -56,14 +61,9 @@ const textResources: Record<string, { body: string; contentType: string }> = {
   },
 };
 
-function markdownFor(request: Request, pathname: string): string | undefined {
+function markdownFor(pathname: string): string | undefined {
   if (pathname === "/") {
-    return detectLocale(request) === "de" ? deMarkdown : indexMarkdown;
-  }
-  if (pathname === "/privacy") {
-    return detectLocale(request) === "de"
-      ? privacyDeMarkdown
-      : privacyEnMarkdown;
+    return indexMarkdown;
   }
   return markdownRoutes[pathname];
 }
@@ -202,7 +202,18 @@ export async function contentResponseFor(
     );
   }
 
-  const markdown = markdownFor(request, pathname);
+  const redirectPath = permanentRedirects[pathname];
+  if (redirectPath) {
+    requestUrl.pathname = redirectPath;
+    return applyResponseHeaders(
+      new Response(null, {
+        status: 308,
+        headers: { Location: requestUrl.href },
+      }),
+    );
+  }
+
+  const markdown = markdownFor(pathname);
   const textResource = textResources[pathname];
 
   if (pathname === "/.well-known/agent-skills/index.json") {

--- a/src/pages/de/datenschutz.astro
+++ b/src/pages/de/datenschutz.astro
@@ -1,0 +1,5 @@
+---
+import PrivacyPage from "../privacy.astro";
+---
+
+<PrivacyPage locale="de" />

--- a/src/pages/en/privacy.astro
+++ b/src/pages/en/privacy.astro
@@ -1,0 +1,5 @@
+---
+import PrivacyPage from "../privacy.astro";
+---
+
+<PrivacyPage locale="en" />

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -3,9 +3,13 @@ import Layout from "../layouts/Layout.astro";
 import EdgeBlur from "../components/EdgeBlur.astro";
 import InteractiveLink from "../components/InteractiveLink.astro";
 import ArrowIcon from "../components/icons/ArrowIcon.astro";
-import { detectLocale } from "../lib/i18n";
+import type { Locale } from "../lib/locale";
 
-const locale = detectLocale(Astro.request);
+interface Props {
+  locale?: Locale;
+}
+
+const locale = Astro.props.locale ?? "en";
 const de = locale === "de";
 const title = de
   ? "Datenschutzerklärung · Jan-Marlon Leibl"
@@ -15,7 +19,16 @@ const description = de
   : "How itsjan.dev handles personal data.";
 ---
 
-<Layout title={title} description={description}>
+<Layout
+  title={title}
+  description={description}
+  markdownPath={`/privacy.${locale}.md`}
+  alternatePaths={{
+    en: "/en/privacy",
+    de: "/de/datenschutz",
+    "x-default": "/en/privacy",
+  }}
+>
   <div class="privacy-shell">
     <EdgeBlur />
     <EdgeBlur edge="bottom" />
@@ -23,7 +36,7 @@ const description = de
       <InteractiveLink
         variant="text"
         class="hero-project-link privacy-back"
-        href="/"
+        href={de ? "/de" : "/en"}
       >
         <ArrowIcon direction="left" />
         <span>{de ? "Zurück zur Startseite" : "Back home"}</span>


### PR DESCRIPTION
## Summary

- publish stable English and German privacy URLs
- add self-canonicals plus reciprocal `en`, `de`, and `x-default` hreflang links
- permanently redirect legacy `/privacy` requests to `/en/privacy`
- exclude the redirecting legacy URL from the sitemap
- point consent and back links at the matching locale
- cover HTML, Markdown, redirects, sitemap output, and Lighthouse routes

## Indexation decision

The privacy content remains indexable under `/en/privacy` and `/de/datenschutz`. The legacy adaptive URL no longer serves content and is not listed in the sitemap.

## Validation

- `bun run ci`

Closes #33
