### PR TITLE
feat: redirect www to the canonical domain

### DIFF
--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -40,6 +40,25 @@ describe("contentResponseFor", () => {
     expect(response).toBeUndefined();
   });
 
+  test("consolidates www, HTTPS, path, and query in one redirect", async () => {
+    const response = await contentResponseFor(
+      new Request("http://www.itsjan.dev/en/?source=backlink"),
+    );
+
+    expect(response?.status).toBe(308);
+    expect(response?.headers.get("Location")).toBe(
+      "https://itsjan.dev/en?source=backlink",
+    );
+  });
+
+  test("does not redirect the canonical apex hostname", async () => {
+    const response = await contentResponseFor(
+      new Request("https://itsjan.dev/en"),
+    );
+
+    expect(response).toBeUndefined();
+  });
+
   test("redirects the legacy privacy URL to the stable English route", async () => {
     const response = await contentResponseFor(
       new Request("https://preview.example/privacy?source=footer"),

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -191,9 +191,15 @@ export async function contentResponseFor(
 ): Promise<Response | undefined> {
   const requestUrl = new URL(request.url);
   const pathname = requestUrl.pathname.replace(/\/+$/, "") || "/";
+  const usesCanonicalHost = requestUrl.hostname !== "www.itsjan.dev";
 
-  if (requestUrl.pathname !== pathname) {
+  if (requestUrl.pathname !== pathname || !usesCanonicalHost) {
     requestUrl.pathname = pathname;
+    if (!usesCanonicalHost) {
+      requestUrl.protocol = "https:";
+      requestUrl.hostname = "itsjan.dev";
+      requestUrl.port = "";
+    }
     return applyResponseHeaders(
       new Response(null, {
         status: 308,

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -2,6 +2,16 @@
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "itsjan-personal-page",
   "compatibility_date": "2026-03-10",
+  "routes": [
+    {
+      "pattern": "itsjan.dev",
+      "custom_domain": true,
+    },
+    {
+      "pattern": "www.itsjan.dev",
+      "custom_domain": true,
+    },
+  ],
   "vars": {
     // These values are public browser configuration, not secrets.
     "PUBLIC_POSTHOG_PROJECT_TOKEN": "phc_AjhL5JJU9TGMCGnMkDKSs9kprYPsRhr6WfxQwJZA5KNf",


### PR DESCRIPTION
## Summary

- declare apex and `www` as Cloudflare Worker Custom Domains
- rely on Cloudflare's automatic DNS and certificate provisioning
- consolidate `www`, HTTP, trailing slashes, paths, and query strings in one permanent redirect
- protect the canonical apex host from redirect loops
- cover redirect behavior with middleware tests

## Cloudflare configuration

Cloudflare's current Custom Domains documentation confirms that this configuration provisions the DNS records and certificates automatically. Production behavior will be verified after the merged build is deployed.

## Validation

- `bun run ci`
- generated `dist/server/wrangler.json` contains both Custom Domain routes

Closes #34
