### PR TITLE
feat: model localized pages with schema entities

### DIFF
--- a/scripts/browser-smoke.mjs
+++ b/scripts/browser-smoke.mjs
@@ -171,6 +171,36 @@ try {
     /Jan-Marlon Leibl · Software developer from Bremen/,
   );
 
+  const profileSchemas = [];
+  for (const [path, language] of [
+    ["/", "en"],
+    ["/en", "en"],
+    ["/de", "de"],
+  ]) {
+    const response = await fetch(`${baseUrl}${path}`);
+    const html = await response.text();
+    const source = html.match(
+      /<script type="application\/ld\+json">([^<]+)<\/script>/,
+    )?.[1];
+    assert.ok(source);
+    const schema = JSON.parse(source);
+    const pageEntity = schema["@graph"].find(
+      (entity) => entity["@type"] === "ProfilePage",
+    );
+    assert.equal(pageEntity.inLanguage, language);
+    assert.equal(pageEntity.mainEntity["@id"], "https://itsjan.dev/#person");
+    assert.equal(pageEntity.isPartOf["@id"], "https://itsjan.dev/#website");
+    profileSchemas.push(schema);
+  }
+  assert.deepEqual(
+    profileSchemas.map((schema) => schema["@graph"][0]),
+    Array(3).fill(profileSchemas[0]["@graph"][0]),
+  );
+  assert.deepEqual(
+    profileSchemas.map((schema) => schema["@graph"][1]),
+    Array(3).fill(profileSchemas[0]["@graph"][1]),
+  );
+
   browser = await chromium.launch({
     executablePath: browserExecutable,
     headless: true,

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -7,11 +7,11 @@ import InteractionRuntime from "../components/InteractionRuntime.astro";
 import PostHog from "../components/posthog.astro";
 import { detectLocale, tr } from "../lib/i18n";
 import type { Locale } from "../lib/locale";
+import { buildPageSchema } from "../lib/schema";
 import {
   CONTACT_EMAIL,
   OPEN_GRAPH_IMAGE_URL,
   PERSON_NAME,
-  PROFILE_IMAGE_URL,
   SITE_ORIGIN,
   SITE_NAME,
   SOCIAL_HANDLES,
@@ -55,6 +55,13 @@ const markdownUrl = markdownPath ? `${SITE_ORIGIN}${markdownPath}` : undefined;
 const alternatePaths =
   props.alternatePaths ??
   (isPortfolioPage ? { en: "/en", de: "/de", "x-default": "/" } : undefined);
+const pageSchema = buildPageSchema({
+  type: isPortfolioPage ? "ProfilePage" : "WebPage",
+  url,
+  title,
+  description,
+  locale,
+});
 
 if (requestUrl.pathname === "/" || requestUrl.pathname === "") {
   Astro.response.headers.set("Link", '</llms.txt>; rel="describedby"');
@@ -132,45 +139,7 @@ if (requestUrl.pathname === "/" || requestUrl.pathname === "") {
     <script
       is:inline
       type="application/ld+json"
-      set:html={JSON.stringify({
-        "@context": "https://schema.org",
-        "@graph": [
-          {
-            "@type": "Person",
-            "@id": `${SITE_ORIGIN}/#person`,
-            name: PERSON_NAME,
-            url: SITE_ORIGIN,
-            image: PROFILE_IMAGE_URL,
-            jobTitle: copy.meta.jobTitle,
-            email: CONTACT_EMAIL,
-            address: {
-              "@type": "PostalAddress",
-              addressLocality: "Bremen",
-              addressCountry: "DE",
-            },
-            sameAs: Object.values(SOCIAL_LINKS),
-            knowsAbout: [
-              "PHP",
-              "TypeScript",
-              "React",
-              "Next.js",
-              "TYPO3",
-              "Symfony",
-              "Cloudflare",
-            ],
-            mainEntityOfPage: url,
-          },
-          {
-            "@type": "WebSite",
-            "@id": `${SITE_ORIGIN}/#website`,
-            name: SITE_NAME,
-            url: SITE_ORIGIN,
-            description,
-            inLanguage: copy.htmlLang,
-            publisher: { "@id": `${SITE_ORIGIN}/#person` },
-          },
-        ],
-      })}
+      set:html={JSON.stringify(pageSchema)}
     />
     <script
       is:inline

--- a/src/lib/schema.test.ts
+++ b/src/lib/schema.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { buildPageSchema } from "./schema";
+
+const pageSchema = (
+  locale: "en" | "de",
+  path: string,
+  type: "ProfilePage" | "WebPage" = "ProfilePage",
+) =>
+  buildPageSchema({
+    type,
+    url: `https://itsjan.dev${path}`,
+    title: locale === "de" ? "Deutsches Portfolio" : "English portfolio",
+    description:
+      locale === "de" ? "Deutsche Beschreibung" : "English description",
+    locale,
+  });
+
+describe("buildPageSchema", () => {
+  test("keeps Person and WebSite entities stable across locales", () => {
+    const english = pageSchema("en", "/en");
+    const german = pageSchema("de", "/de");
+
+    expect(english["@graph"][0]).toEqual(german["@graph"][0]);
+    expect(english["@graph"][1]).toEqual(german["@graph"][1]);
+    expect(english["@graph"][1].inLanguage).toEqual(["en", "de"]);
+  });
+
+  test("creates a unique localized ProfilePage connected to stable entities", () => {
+    const schema = pageSchema("de", "/de");
+    const page = schema["@graph"][2];
+
+    expect(page).toMatchObject({
+      "@type": "ProfilePage",
+      "@id": "https://itsjan.dev/de#page",
+      url: "https://itsjan.dev/de",
+      name: "Deutsches Portfolio",
+      description: "Deutsche Beschreibung",
+      inLanguage: "de",
+      isPartOf: { "@id": "https://itsjan.dev/#website" },
+      mainEntity: { "@id": "https://itsjan.dev/#person" },
+    });
+  });
+
+  test("uses an author relationship for non-profile pages", () => {
+    const schema = pageSchema("en", "/en/privacy", "WebPage");
+    const page = schema["@graph"][2];
+
+    expect(page["@type"]).toBe("WebPage");
+    expect(page).toHaveProperty("author", {
+      "@id": "https://itsjan.dev/#person",
+    });
+    expect(page).not.toHaveProperty("mainEntity");
+  });
+});

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -1,0 +1,82 @@
+import type { Locale } from "./locale";
+import {
+  CONTACT_EMAIL,
+  PERSON_NAME,
+  PROFILE_IMAGE_URL,
+  SITE_NAME,
+  SITE_ORIGIN,
+  SOCIAL_LINKS,
+} from "./site";
+
+export type PageSchemaType = "ProfilePage" | "WebPage";
+
+interface PageSchemaInput {
+  type: PageSchemaType;
+  url: string;
+  title: string;
+  description: string;
+  locale: Locale;
+}
+
+export function buildPageSchema({
+  type,
+  url,
+  title,
+  description,
+  locale,
+}: PageSchemaInput) {
+  const personId = `${SITE_ORIGIN}/#person`;
+  const websiteId = `${SITE_ORIGIN}/#website`;
+  const pageId = `${url}#page`;
+  const personReference = { "@id": personId };
+
+  return {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "Person",
+        "@id": personId,
+        name: PERSON_NAME,
+        url: SITE_ORIGIN,
+        image: PROFILE_IMAGE_URL,
+        jobTitle: "Software Developer",
+        email: CONTACT_EMAIL,
+        address: {
+          "@type": "PostalAddress",
+          addressLocality: "Bremen",
+          addressCountry: "DE",
+        },
+        sameAs: Object.values(SOCIAL_LINKS),
+        knowsAbout: [
+          "PHP",
+          "TypeScript",
+          "React",
+          "Next.js",
+          "TYPO3",
+          "Symfony",
+          "Cloudflare",
+        ],
+      },
+      {
+        "@type": "WebSite",
+        "@id": websiteId,
+        name: SITE_NAME,
+        url: SITE_ORIGIN,
+        inLanguage: ["en", "de"],
+        publisher: personReference,
+      },
+      {
+        "@type": type,
+        "@id": pageId,
+        url,
+        name: title,
+        description,
+        inLanguage: locale,
+        isPartOf: { "@id": websiteId },
+        ...(type === "ProfilePage"
+          ? { mainEntity: personReference }
+          : { author: personReference }),
+      },
+    ],
+  };
+}


### PR DESCRIPTION
## Summary

- keep one stable `Person` and one multilingual `WebSite` entity
- add a unique localized `ProfilePage` entity for each portfolio URL
- connect profile pages with `mainEntity` and `isPartOf`
- model non-profile routes as authored `WebPage` entities
- centralize and unit-test JSON-LD generation
- parse and verify rendered JSON-LD on `/`, `/en`, and `/de`

## Validation

- `bun run ci`

Closes #36
