### PR TITLE
feat: strengthen localized portfolio metadata

### DIFF
--- a/scripts/browser-smoke.mjs
+++ b/scripts/browser-smoke.mjs
@@ -172,10 +172,22 @@ try {
   );
 
   const profileSchemas = [];
-  for (const [path, language] of [
-    ["/", "en"],
-    ["/en", "en"],
-    ["/de", "de"],
+  for (const [path, language, expectedDescription] of [
+    [
+      "/",
+      "en",
+      "Jan-Marlon Leibl is a software developer from Bremen building Finny, Ventry and modern web products with PHP, TypeScript, React, Next.js and Cloudflare.",
+    ],
+    [
+      "/en",
+      "en",
+      "Jan-Marlon Leibl is a software developer from Bremen building Finny, Ventry and modern web products with PHP, TypeScript, React, Next.js and Cloudflare.",
+    ],
+    [
+      "/de",
+      "de",
+      "Jan-Marlon Leibl ist Softwareentwickler aus Bremen und entwickelt Finny, Ventry und moderne Webprojekte mit PHP, TypeScript, React, Next.js und Cloudflare.",
+    ],
   ]) {
     const response = await fetch(`${baseUrl}${path}`);
     const html = await response.text();
@@ -184,6 +196,22 @@ try {
     )?.[1];
     assert.ok(source);
     const schema = JSON.parse(source);
+    assert.match(
+      html,
+      new RegExp(`<meta name="description" content="${expectedDescription}">`),
+    );
+    assert.match(
+      html,
+      new RegExp(
+        `<meta property="og:description" content="${expectedDescription}">`,
+      ),
+    );
+    assert.match(
+      html,
+      new RegExp(
+        `<meta name="twitter:description" content="${expectedDescription}">`,
+      ),
+    );
     const pageEntity = schema["@graph"].find(
       (entity) => entity["@type"] === "ProfilePage",
     );

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -34,11 +34,7 @@ const title =
   (locale === "de"
     ? "Jan-Marlon Leibl · Softwareentwickler aus Bremen"
     : "Jan-Marlon Leibl · Software developer from Bremen");
-const description =
-  props.description ??
-  (locale === "de"
-    ? "Ich bin Jan-Marlon, Softwareentwickler aus Bremen und der Kopf hinter Finny, einer App für Belege und Garantiefristen."
-    : "I'm Jan-Marlon, a software developer from Bremen and the person behind Finny, an app for receipts and warranty reminders.");
+const description = props.description ?? copy.meta.description;
 const requestUrl = new URL(Astro.request.url);
 const pathname = requestUrl.pathname.replace(/\/$/, "") || "/";
 const isPortfolioPage =

--- a/src/lib/i18n.test.ts
+++ b/src/lib/i18n.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { tr } from "./i18n";
+
+describe("localized metadata", () => {
+  test("keeps portfolio descriptions unique and search-result friendly", () => {
+    const english = tr("en").meta.description;
+    const german = tr("de").meta.description;
+
+    expect(english).not.toBe(german);
+    expect(english.length).toBeWithin(140, 160);
+    expect(german.length).toBeWithin(140, 160);
+  });
+
+  test("describes visible portfolio work and technologies", () => {
+    for (const description of [
+      tr("en").meta.description,
+      tr("de").meta.description,
+    ]) {
+      expect(description).toContain("Finny");
+      expect(description).toContain("Ventry");
+      expect(description).toContain("PHP");
+      expect(description).toContain("TypeScript");
+      expect(description).toContain("React");
+    }
+  });
+});

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -16,6 +16,7 @@ interface Strings {
   meta: {
     imageAlt: string;
     jobTitle: string;
+    description: string;
   };
   privacyConsent: {
     title: string;
@@ -135,6 +136,8 @@ const en: Strings = {
   meta: {
     imageAlt: "Jan-Marlon Leibl's portfolio",
     jobTitle: "Software Developer",
+    description:
+      "Jan-Marlon Leibl is a software developer from Bremen building Finny, Ventry and modern web products with PHP, TypeScript, React, Next.js and Cloudflare.",
   },
   privacyConsent: {
     title: "Privacy settings",
@@ -303,6 +306,8 @@ const de: Strings = {
   meta: {
     imageAlt: "Portfolio von Jan-Marlon Leibl",
     jobTitle: "Softwareentwickler",
+    description:
+      "Jan-Marlon Leibl ist Softwareentwickler aus Bremen und entwickelt Finny, Ventry und moderne Webprojekte mit PHP, TypeScript, React, Next.js und Cloudflare.",
   },
   privacyConsent: {
     title: "Datenschutz-Einstellungen",


### PR DESCRIPTION
## Summary

- add specific 152- and 155-character English/German portfolio descriptions
- cover role, location, Finny, Ventry, and the visible technology stack naturally
- share one localized source across HTML, Open Graph, Twitter, and page schema
- validate length, uniqueness, claims, and rendered metadata

## Validation

- `bun run ci`

Closes #28
