### PR TITLE
feat(seo): strengthen heading semantics

### DIFF
--- a/scripts/browser-smoke.mjs
+++ b/scripts/browser-smoke.mjs
@@ -191,10 +191,20 @@ try {
   ]) {
     const response = await fetch(`${baseUrl}${path}`);
     const html = await response.text();
+    const headingLevels = [
+      ...html.matchAll(/<h([1-6])(?:\s[^>]*)?>([\s\S]*?)<\/h\1>/g),
+    ].map(([, level]) => Number(level));
     const source = html.match(
       /<script type="application\/ld\+json">([^<]+)<\/script>/,
     )?.[1];
     assert.ok(source);
+    assert.equal(headingLevels.filter((level) => level === 1).length, 1);
+    assert.equal(
+      headingLevels.some(
+        (level, index) => index > 0 && level > headingLevels[index - 1] + 1,
+      ),
+      false,
+    );
     const schema = JSON.parse(source);
     assert.match(
       html,
@@ -287,9 +297,46 @@ try {
     "Jan-Marlon Leibl · Software developer from Bremen",
   );
   assert.equal(
-    (await page.locator("h1").first().textContent())?.trim(),
-    "Jan-Marlon Leibl",
+    (await page.locator("h1").first().textContent())
+      ?.replace(/\s+/g, " ")
+      .trim(),
+    "Jan-Marlon Leibl, software developer from Bremen",
   );
+  assert.equal(await page.locator("h1").count(), 1);
+  assert.deepEqual(await page.locator("#projects h3").allTextContents(), [
+    "Finny receipt and warranty app",
+    "Ventry expiring file sharing",
+  ]);
+  const semanticPage = await context.newPage();
+  for (const [path, expectedH1, expectedProjects] of [
+    [
+      "/en",
+      "Jan-Marlon Leibl, software developer from Bremen",
+      ["Finny receipt and warranty app", "Ventry expiring file sharing"],
+    ],
+    [
+      "/de",
+      "Jan-Marlon Leibl, Softwareentwickler aus Bremen",
+      [
+        "Finny für Belege und Garantien",
+        "Ventry für zeitlich begrenzte Dateifreigaben",
+      ],
+    ],
+  ]) {
+    await semanticPage.goto(`${baseUrl}${path}`);
+    assert.equal(await semanticPage.locator("h1").count(), 1);
+    assert.equal(
+      (await semanticPage.locator("h1").textContent())
+        ?.replace(/\s+/g, " ")
+        .trim(),
+      expectedH1,
+    );
+    assert.deepEqual(
+      await semanticPage.locator("#projects h3").allTextContents(),
+      expectedProjects,
+    );
+  }
+  await semanticPage.close();
   assert.equal(await page.locator(".activity-reveal").count(), 1);
   assert.equal(await page.locator(".activity-reveal [tabindex]").count(), 0);
   assert.ok(

--- a/src/components/home/ProfileSection.astro
+++ b/src/components/home/ProfileSection.astro
@@ -11,7 +11,12 @@ import ArrowIcon from "../icons/ArrowIcon.astro";
 interface Props {
   copy: Pick<
     PortfolioCopy,
-    "avatar" | "theme" | "intro" | "subtitle" | "subtitleStates"
+    | "avatar"
+    | "headingContext"
+    | "theme"
+    | "intro"
+    | "subtitle"
+    | "subtitleStates"
   >;
   locale: Locale;
   currentAge: number;
@@ -66,7 +71,9 @@ const { copy, locale, currentAge } = Astro.props;
       </span>
     </InteractiveButton>
   </div>
-  <h1 class="text-2xl font-medium tracking-tight">{PERSON_NAME}</h1>
+  <h1 class="text-2xl font-medium tracking-tight">
+    {PERSON_NAME}<span class="sr-only">, {copy.headingContext}</span>
+  </h1>
   <p
     class="profile-subtitle mt-1 text-sm leading-5 text-[var(--text-tertiary)]"
     data-text-states={JSON.stringify(copy.subtitleStates(currentAge))}

--- a/src/components/home/ProjectsSection.astro
+++ b/src/components/home/ProjectsSection.astro
@@ -47,6 +47,11 @@ const { heading, finny, ventry } = Astro.props;
           >
         </div>
         <div class="project-preview-copy p-4">
+          <h3
+            class="mb-2 text-base leading-6 font-medium tracking-tight text-[var(--text)]"
+          >
+            {finny.heading}
+          </h3>
           <p
             class="text-[15px] leading-6 font-normal text-[var(--text-secondary)]"
           >
@@ -133,6 +138,11 @@ const { heading, finny, ventry } = Astro.props;
           </span>
         </div>
         <div class="project-preview-copy p-4">
+          <h3
+            class="mb-2 text-base leading-6 font-medium tracking-tight text-[var(--text)]"
+          >
+            {ventry.heading}
+          </h3>
           <p
             class="text-[15px] leading-6 font-normal text-[var(--text-secondary)]"
           >

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -28,6 +28,7 @@ interface Strings {
     privacy: string;
   };
   portfolio: {
+    headingContext: string;
     subtitle: (age: number) => string;
     subtitleStates: (age: number) => string[];
     avatar: {
@@ -94,6 +95,7 @@ interface Strings {
     };
     finny: {
       id: Extract<ProjectId, "finny">;
+      heading: string;
       linkAria: string;
       previewAria: string;
       receiptTitle: string;
@@ -115,6 +117,7 @@ interface Strings {
     };
     ventry: {
       id: Extract<ProjectId, "ventry">;
+      heading: string;
       linkAria: string;
       previewAria: string;
       panelTitle: string;
@@ -149,6 +152,7 @@ const en: Strings = {
     privacy: "Privacy policy",
   },
   portfolio: {
+    headingContext: "software developer from Bremen",
     subtitle: (age) => `${age}, software developer from Bremen`,
     subtitleStates: (age) => [
       `${age}, software developer from Bremen`,
@@ -262,6 +266,7 @@ const en: Strings = {
     },
     finny: {
       id: "finny",
+      heading: "Finny receipt and warranty app",
       linkAria: "Open Finny",
       previewAria: "Preview of Finny",
       receiptTitle: "RECEIPT",
@@ -283,6 +288,7 @@ const en: Strings = {
     },
     ventry: {
       id: "ventry",
+      heading: "Ventry expiring file sharing",
       linkAria: "Open Ventry",
       previewAria: "Preview of Ventry",
       panelTitle: "RECENT UPLOADS",
@@ -319,6 +325,7 @@ const de: Strings = {
     privacy: "Datenschutzerklärung",
   },
   portfolio: {
+    headingContext: "Softwareentwickler aus Bremen",
     subtitle: (age) => `${age}, Softwareentwickler aus Bremen`,
     subtitleStates: (age) => [
       `${age}, Softwareentwickler aus Bremen`,
@@ -432,6 +439,7 @@ const de: Strings = {
     },
     finny: {
       id: "finny",
+      heading: "Finny für Belege und Garantien",
       linkAria: "Finny öffnen",
       previewAria: "Vorschau von Finny",
       receiptTitle: "BELEG",
@@ -453,6 +461,7 @@ const de: Strings = {
     },
     ventry: {
       id: "ventry",
+      heading: "Ventry für zeitlich begrenzte Dateifreigaben",
       linkAria: "Ventry öffnen",
       previewAria: "Vorschau von Ventry",
       panelTitle: "LETZTE DATEIEN",

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1031,7 +1031,7 @@ html[data-theme="dark"] .ventry-file-row b {
   transition-duration: 180ms;
   transition-timing-function: var(--ease-smooth-out);
 }
-.project-preview-copy > p:first-child {
+.project-preview-copy > p {
   text-wrap: pretty;
 }
 


### PR DESCRIPTION
## Summary

- make the single portfolio H1 describe Jan's role and Bremen location to assistive technology without changing the visual hierarchy
- add visible localized H3 headings to both project cards
- cover English and German heading count, order, accessible text, and rendered project headings in browser smoke tests

## Validation

- `bun run ci`
- desktop visual QA at 1440×1000
- mobile visual QA at 390×844

Closes #29
