### PR TITLE
feat(seo): add localized project content architecture

### DIFF
--- a/.lighthouserc.cjs
+++ b/.lighthouserc.cjs
@@ -13,6 +13,8 @@ module.exports = {
         "http://127.0.0.1:4327/en",
         "http://127.0.0.1:4327/en/privacy",
         "http://127.0.0.1:4327/de/datenschutz",
+        "http://127.0.0.1:4327/en/projects",
+        "http://127.0.0.1:4327/de/projekte",
       ],
       numberOfRuns: 3,
       startServerCommand:

--- a/docs/seo/project-content-architecture.md
+++ b/docs/seo/project-content-architecture.md
@@ -1,0 +1,33 @@
+# Localized project content architecture
+
+Project content uses explicit locale routes and stable brand slugs. A page is added to the sitemap only when its English or German main content is complete; empty case-study routes are never published.
+
+## Routes
+
+| Content           | English               | German                |
+| ----------------- | --------------------- | --------------------- |
+| Project index     | `/en/projects`        | `/de/projekte`        |
+| Finny case study  | `/en/projects/finny`  | `/de/projekte/finny`  |
+| Ventry case study | `/en/projects/ventry` | `/de/projekte/ventry` |
+
+Every page self-canonicalizes without a trailing slash and declares reciprocal `en`, `de`, and `x-default` hreflang links. `x-default` points to the English page. Brand slugs stay identical across locales; only the index segment is translated.
+
+## Content model
+
+`ProjectCaseStudy` in `src/data/project-content.ts` is the source contract. Every localized case study must provide:
+
+- identity, locale, canonical route, alternate route, and external product URL;
+- page title, search metadata, summary, development period, and current status;
+- the problem, Jan's role, architecture, technologies, decisions, challenges, and outcomes;
+- responsive images with intrinsic dimensions and meaningful alt text, or an accessible diagram with a text description.
+
+Claims must be supported by repository history, the public product, or material supplied by Jan. Metrics, customers, and outcomes must not be inferred.
+
+## Search and linking rules
+
+- Project indexes use `CollectionPage`; case studies use `Article`, connected to the stable site `Person` and `WebSite` entities.
+- Metadata is written independently in each locale and describes visible page content.
+- A complete page is included in the canonical sitemap and covered by browser and Lighthouse checks.
+- Homepage project headings link descriptively into the matching localized project content. Product CTAs remain separate external links.
+- Case studies link back to the localized project index and to the external product using the canonical product URL.
+- The site exposes localized URLs through links, hreflang, and the sitemap. It intentionally does not add a language switcher.

--- a/scripts/browser-smoke.mjs
+++ b/scripts/browser-smoke.mjs
@@ -108,8 +108,10 @@ try {
     "https://itsjan.dev",
     "https://itsjan.dev/de",
     "https://itsjan.dev/de/datenschutz",
+    "https://itsjan.dev/de/projekte",
     "https://itsjan.dev/en",
     "https://itsjan.dev/en/privacy",
+    "https://itsjan.dev/en/projects",
   ]);
 
   const legacyPrivacyResponse = await fetch(`${baseUrl}/privacy`, {
@@ -139,6 +141,63 @@ try {
         `hreflang="${language === "en" ? "de" : "en"}" href="https://itsjan.dev${alternate}"`,
       ),
     );
+  }
+
+  for (const [
+    path,
+    language,
+    alternate,
+    expectedTitle,
+    expectedDescription,
+  ] of [
+    [
+      "/en/projects",
+      "en",
+      "/de/projekte",
+      "Software projects by Jan-Marlon Leibl",
+      "Explore Jan-Marlon Leibl's Finny warranty app and Ventry file-sharing project, including their purpose, development period and technologies.",
+    ],
+    [
+      "/de/projekte",
+      "de",
+      "/en/projects",
+      "Softwareprojekte von Jan-Marlon Leibl",
+      "Entdecke Jan-Marlon Leibls Garantie-App Finny und das Filesharing-Projekt Ventry mit Zweck, Entwicklungszeitraum und Technologien.",
+    ],
+  ]) {
+    const response = await fetch(`${baseUrl}${path}`);
+    const html = await response.text();
+    const schemaSource = html.match(
+      /<script type="application\/ld\+json">([^<]+)<\/script>/,
+    )?.[1];
+    assert.equal(response.status, 200);
+    assert.ok(schemaSource);
+    assert.ok(html.includes(`<html lang="${language}"`));
+    assert.ok(
+      html.includes(`rel="canonical" href="https://itsjan.dev${path}"`),
+    );
+    assert.ok(
+      html.includes(
+        `hreflang="${language === "en" ? "de" : "en"}" href="https://itsjan.dev${alternate}"`,
+      ),
+    );
+    assert.ok(
+      html.includes(
+        `hreflang="x-default" href="https://itsjan.dev/en/projects"`,
+      ),
+    );
+    assert.ok(
+      html.includes(
+        `<meta name="description" content="${expectedDescription}"`,
+      ),
+    );
+    assert.ok(html.includes(expectedTitle));
+    const pageEntity = JSON.parse(schemaSource)["@graph"].find(
+      (entity) => entity["@type"] === "CollectionPage",
+    );
+    assert.equal(pageEntity.url, `https://itsjan.dev${path}`);
+    assert.equal(pageEntity.inLanguage, language);
+    assert.equal(pageEntity.author["@id"], "https://itsjan.dev/#person");
   }
 
   const staticImageResponse = await fetch(`${baseUrl}/favicon.png`);
@@ -308,11 +367,12 @@ try {
     "Ventry expiring file sharing",
   ]);
   const semanticPage = await context.newPage();
-  for (const [path, expectedH1, expectedProjects] of [
+  for (const [path, expectedH1, expectedProjects, projectIndexPath] of [
     [
       "/en",
       "Jan-Marlon Leibl, software developer from Bremen",
       ["Finny receipt and warranty app", "Ventry expiring file sharing"],
+      "/en/projects",
     ],
     [
       "/de",
@@ -321,6 +381,7 @@ try {
         "Finny für Belege und Garantien",
         "Ventry für zeitlich begrenzte Dateifreigaben",
       ],
+      "/de/projekte",
     ],
   ]) {
     await semanticPage.goto(`${baseUrl}${path}`);
@@ -334,6 +395,47 @@ try {
     assert.deepEqual(
       await semanticPage.locator("#projects h3").allTextContents(),
       expectedProjects,
+    );
+    assert.deepEqual(
+      await semanticPage
+        .locator("#projects h3 a")
+        .evaluateAll((links) => links.map((link) => link.getAttribute("href"))),
+      [`${projectIndexPath}#finny`, `${projectIndexPath}#ventry`],
+    );
+  }
+  for (const [path, expectedH1, expectedProjectTitles] of [
+    [
+      "/en/projects",
+      "Software projects by Jan-Marlon Leibl",
+      [
+        "Finny — receipts and warranty reminders",
+        "Ventry — expiring file sharing",
+      ],
+    ],
+    [
+      "/de/projekte",
+      "Softwareprojekte von Jan-Marlon Leibl",
+      [
+        "Finny — Belege und Garantie-Erinnerungen",
+        "Ventry — zeitlich begrenztes Filesharing",
+      ],
+    ],
+  ]) {
+    await semanticPage.goto(`${baseUrl}${path}`);
+    assert.equal(await semanticPage.locator("h1").textContent(), expectedH1);
+    assert.deepEqual(
+      await semanticPage.locator(".project-index-card h2").allTextContents(),
+      expectedProjectTitles,
+    );
+    assert.equal(
+      await semanticPage.locator(".project-index-external").count(),
+      2,
+    );
+    assert.deepEqual(
+      await semanticPage
+        .locator(".project-index-external")
+        .evaluateAll((links) => links.map((link) => link.getAttribute("href"))),
+      ["https://fnny.app", "https://ventry.host"],
     );
   }
   await semanticPage.close();

--- a/src/components/home/ProjectsSection.astro
+++ b/src/components/home/ProjectsSection.astro
@@ -10,9 +10,10 @@ interface Props {
   heading: string;
   finny: PortfolioCopy["finny"];
   ventry: PortfolioCopy["ventry"];
+  projectIndexPath: string;
 }
 
-const { heading, finny, ventry } = Astro.props;
+const { heading, finny, ventry, projectIndexPath } = Astro.props;
 ---
 
 <section id="projects">
@@ -50,7 +51,10 @@ const { heading, finny, ventry } = Astro.props;
           <h3
             class="mb-2 text-base leading-6 font-medium tracking-tight text-[var(--text)]"
           >
-            {finny.heading}
+            <a
+              class="project-preview-heading-link"
+              href={`${projectIndexPath}#${finny.id}`}>{finny.heading}</a
+            >
           </h3>
           <p
             class="text-[15px] leading-6 font-normal text-[var(--text-secondary)]"
@@ -141,7 +145,10 @@ const { heading, finny, ventry } = Astro.props;
           <h3
             class="mb-2 text-base leading-6 font-medium tracking-tight text-[var(--text)]"
           >
-            {ventry.heading}
+            <a
+              class="project-preview-heading-link"
+              href={`${projectIndexPath}#${ventry.id}`}>{ventry.heading}</a
+            >
           </h3>
           <p
             class="text-[15px] leading-6 font-normal text-[var(--text-secondary)]"

--- a/src/components/pages/ProjectIndexPage.astro
+++ b/src/components/pages/ProjectIndexPage.astro
@@ -1,0 +1,85 @@
+---
+import EdgeBlur from "../EdgeBlur.astro";
+import InteractiveLink from "../InteractiveLink.astro";
+import ArrowIcon from "../icons/ArrowIcon.astro";
+import {
+  PROJECT_INDEX_CONTENT,
+  PROJECT_ROUTES,
+} from "../../data/project-content";
+import { ALL_TECHNOLOGIES } from "../../data/technologies";
+import Layout from "../../layouts/Layout.astro";
+import type { Locale } from "../../lib/locale";
+
+interface Props {
+  locale: Locale;
+}
+
+const { locale } = Astro.props;
+const content = PROJECT_INDEX_CONTENT[locale];
+const alternatePaths = {
+  en: PROJECT_ROUTES.en.index,
+  de: PROJECT_ROUTES.de.index,
+  "x-default": PROJECT_ROUTES.en.index,
+};
+const technologyNames = new Map(
+  ALL_TECHNOLOGIES.map(({ id, name }) => [id, name]),
+);
+---
+
+<Layout
+  title={content.metaTitle}
+  description={content.metaDescription}
+  {alternatePaths}
+  schemaType="CollectionPage"
+>
+  <div class="project-index-shell">
+    <EdgeBlur />
+    <EdgeBlur edge="bottom" />
+    <main class="project-index-main">
+      <InteractiveLink
+        variant="text"
+        class="hero-project-link project-page-back"
+        href={locale === "de" ? "/de" : "/en"}
+      >
+        <ArrowIcon direction="left" />
+        <span>{content.backLabel}</span>
+      </InteractiveLink>
+
+      <header class="project-index-header">
+        <p class="project-index-eyebrow">{content.eyebrow}</p>
+        <h1>{content.title}</h1>
+        <p>{content.introduction}</p>
+      </header>
+
+      <div class="project-index-list">
+        {
+          content.projects.map((project) => (
+            <article id={project.id} class="project-index-card">
+              <div class="project-index-meta">
+                <span>{project.period}</span>
+                <span>{project.status}</span>
+              </div>
+              <h2>{project.title}</h2>
+              <p>{project.summary}</p>
+              <ul aria-label={content.technologyLabel}>
+                {project.technologies.map((technologyId) => (
+                  <li>{technologyNames.get(technologyId)}</li>
+                ))}
+              </ul>
+              <InteractiveLink
+                variant="text"
+                class="project-index-external"
+                href={project.externalUrl}
+                target="_blank"
+                rel="noreferrer"
+              >
+                <span>{project.externalLabel}</span>
+                <ArrowIcon direction="external" />
+              </InteractiveLink>
+            </article>
+          ))
+        }
+      </div>
+    </main>
+  </div>
+</Layout>

--- a/src/data/project-content.test.ts
+++ b/src/data/project-content.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { PROJECT_INDEX_CONTENT, PROJECT_ROUTES } from "./project-content";
+
+describe("localized project content architecture", () => {
+  test("uses stable, distinct route conventions", () => {
+    expect(PROJECT_ROUTES.en).toEqual({
+      index: "/en/projects",
+      finny: "/en/projects/finny",
+      ventry: "/en/projects/ventry",
+    });
+    expect(PROJECT_ROUTES.de).toEqual({
+      index: "/de/projekte",
+      finny: "/de/projekte/finny",
+      ventry: "/de/projekte/ventry",
+    });
+    expect(
+      new Set(Object.values(PROJECT_ROUTES).flatMap(Object.values)).size,
+    ).toBe(6);
+  });
+
+  test("keeps complete translated index entries aligned by stable ID", () => {
+    const english = PROJECT_INDEX_CONTENT.en;
+    const german = PROJECT_INDEX_CONTENT.de;
+
+    expect(english.metaDescription.length).toBeGreaterThanOrEqual(120);
+    expect(english.metaDescription.length).toBeLessThanOrEqual(160);
+    expect(german.metaDescription.length).toBeGreaterThanOrEqual(120);
+    expect(german.metaDescription.length).toBeLessThanOrEqual(160);
+    expect(english.introduction).not.toBe(german.introduction);
+    expect(english.projects.map(({ id }) => id)).toEqual(["finny", "ventry"]);
+    expect(german.projects.map(({ id }) => id)).toEqual(["finny", "ventry"]);
+
+    for (const project of [...english.projects, ...german.projects]) {
+      expect(project.title).toBeTruthy();
+      expect(project.summary).toBeTruthy();
+      expect(project.technologies.length).toBeGreaterThan(0);
+      expect(project.externalUrl).toMatch(/^https:\/\//);
+    }
+  });
+});

--- a/src/data/project-content.ts
+++ b/src/data/project-content.ts
@@ -1,0 +1,148 @@
+import type { Locale } from "../lib/locale";
+import { PROJECTS, type ProjectId } from "./portfolio";
+import type { TechnologyId } from "./technologies";
+
+export const PROJECT_ROUTES = {
+  en: {
+    index: "/en/projects",
+    finny: "/en/projects/finny",
+    ventry: "/en/projects/ventry",
+  },
+  de: {
+    index: "/de/projekte",
+    finny: "/de/projekte/finny",
+    ventry: "/de/projekte/ventry",
+  },
+} as const satisfies Record<Locale, Record<"index" | ProjectId, string>>;
+
+export type ProjectVisual =
+  | {
+      kind: "image";
+      src: string;
+      alt: string;
+      width: number;
+      height: number;
+    }
+  | {
+      kind: "diagram";
+      title: string;
+      description: string;
+      steps: readonly string[];
+    };
+
+export interface ProjectCaseStudy {
+  id: ProjectId;
+  locale: Locale;
+  route: string;
+  alternateRoute: string;
+  externalUrl: string;
+  title: string;
+  metaTitle: string;
+  metaDescription: string;
+  summary: string;
+  period: string;
+  status: string;
+  problem: readonly string[];
+  role: readonly string[];
+  architecture: readonly string[];
+  technologies: readonly TechnologyId[];
+  decisions: readonly { title: string; detail: string }[];
+  challenges: readonly { title: string; detail: string }[];
+  outcomes: readonly string[];
+  visuals: readonly ProjectVisual[];
+}
+
+interface ProjectIndexEntry {
+  id: ProjectId;
+  title: string;
+  summary: string;
+  period: string;
+  status: string;
+  technologies: readonly TechnologyId[];
+  externalUrl: string;
+  externalLabel: string;
+}
+
+export interface ProjectIndexContent {
+  title: string;
+  metaTitle: string;
+  metaDescription: string;
+  eyebrow: string;
+  introduction: string;
+  backLabel: string;
+  technologyLabel: string;
+  projects: readonly ProjectIndexEntry[];
+}
+
+export const PROJECT_INDEX_CONTENT = {
+  en: {
+    title: "Software projects by Jan-Marlon Leibl",
+    metaTitle: "Software projects · Jan-Marlon Leibl",
+    metaDescription:
+      "Explore Jan-Marlon Leibl's Finny warranty app and Ventry file-sharing project, including their purpose, development period and technologies.",
+    eyebrow: "Selected work",
+    introduction:
+      "Two products I built around practical problems: keeping purchase records useful after checkout and sharing files without leaving them online indefinitely.",
+    backLabel: "Back home",
+    technologyLabel: "Technologies",
+    projects: [
+      {
+        id: "finny",
+        title: "Finny — receipts and warranty reminders",
+        summary:
+          "An active project that keeps receipts and purchase details together and sends a reminder before a warranty expires.",
+        period: "Since 2026",
+        status: "Active project",
+        technologies: ["typescript", "react", "nextjs"],
+        externalUrl: PROJECTS.finny.href,
+        externalLabel: "Visit Finny",
+      },
+      {
+        id: "ventry",
+        title: "Ventry — expiring file sharing",
+        summary:
+          "A file-sharing project built around links that expire and files that are removed automatically when their time is up.",
+        period: "2023–2024",
+        status: "Completed project",
+        technologies: ["typescript", "nextjs"],
+        externalUrl: PROJECTS.ventry.href,
+        externalLabel: "Visit Ventry",
+      },
+    ],
+  },
+  de: {
+    title: "Softwareprojekte von Jan-Marlon Leibl",
+    metaTitle: "Softwareprojekte · Jan-Marlon Leibl",
+    metaDescription:
+      "Entdecke Jan-Marlon Leibls Garantie-App Finny und das Filesharing-Projekt Ventry mit Zweck, Entwicklungszeitraum und Technologien.",
+    eyebrow: "Ausgewählte Projekte",
+    introduction:
+      "Zwei Produkte für konkrete Probleme: Kaufunterlagen nach dem Bezahlen nützlich halten und Dateien teilen, ohne sie dauerhaft online zu lassen.",
+    backLabel: "Zurück zur Startseite",
+    technologyLabel: "Technologien",
+    projects: [
+      {
+        id: "finny",
+        title: "Finny — Belege und Garantie-Erinnerungen",
+        summary:
+          "Ein aktives Projekt, das Belege und Kaufdetails zusammenhält und vor dem Ablauf einer Garantie erinnert.",
+        period: "Seit 2026",
+        status: "Aktives Projekt",
+        technologies: ["typescript", "react", "nextjs"],
+        externalUrl: PROJECTS.finny.href,
+        externalLabel: "Finny besuchen",
+      },
+      {
+        id: "ventry",
+        title: "Ventry — zeitlich begrenztes Filesharing",
+        summary:
+          "Ein Filesharing-Projekt mit Links, die ablaufen, und Dateien, die danach automatisch entfernt werden.",
+        period: "2023–2024",
+        status: "Abgeschlossenes Projekt",
+        technologies: ["typescript", "nextjs"],
+        externalUrl: PROJECTS.ventry.href,
+        externalLabel: "Ventry besuchen",
+      },
+    ],
+  },
+} as const satisfies Record<Locale, ProjectIndexContent>;

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -7,7 +7,7 @@ import InteractionRuntime from "../components/InteractionRuntime.astro";
 import PostHog from "../components/posthog.astro";
 import { detectLocale, tr } from "../lib/i18n";
 import type { Locale } from "../lib/locale";
-import { buildPageSchema } from "../lib/schema";
+import { buildPageSchema, type PageSchemaType } from "../lib/schema";
 import {
   CONTACT_EMAIL,
   OPEN_GRAPH_IMAGE_URL,
@@ -24,6 +24,7 @@ interface Props {
   noindex?: boolean;
   alternatePaths?: Partial<Record<Locale | "x-default", string>>;
   markdownPath?: string;
+  schemaType?: PageSchemaType;
 }
 
 const props: Props = Astro.props;
@@ -52,7 +53,7 @@ const alternatePaths =
   props.alternatePaths ??
   (isPortfolioPage ? { en: "/en", de: "/de", "x-default": "/" } : undefined);
 const pageSchema = buildPageSchema({
-  type: isPortfolioPage ? "ProfilePage" : "WebPage",
+  type: props.schemaType ?? (isPortfolioPage ? "ProfilePage" : "WebPage"),
   url,
   title,
   description,

--- a/src/lib/schema.test.ts
+++ b/src/lib/schema.test.ts
@@ -4,7 +4,8 @@ import { buildPageSchema } from "./schema";
 const pageSchema = (
   locale: "en" | "de",
   path: string,
-  type: "ProfilePage" | "WebPage" = "ProfilePage",
+  type:
+    "Article" | "CollectionPage" | "ProfilePage" | "WebPage" = "ProfilePage",
 ) =>
   buildPageSchema({
     type,
@@ -50,5 +51,15 @@ describe("buildPageSchema", () => {
       "@id": "https://itsjan.dev/#person",
     });
     expect(page).not.toHaveProperty("mainEntity");
+  });
+
+  test("supports project indexes and case-study articles", () => {
+    for (const type of ["CollectionPage", "Article"] as const) {
+      const page = pageSchema("en", "/en/projects", type)["@graph"][2];
+      expect(page["@type"]).toBe(type);
+      expect(page).toHaveProperty("author", {
+        "@id": "https://itsjan.dev/#person",
+      });
+    }
   });
 });

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -8,7 +8,8 @@ import {
   SOCIAL_LINKS,
 } from "./site";
 
-export type PageSchemaType = "ProfilePage" | "WebPage";
+export type PageSchemaType =
+  "Article" | "CollectionPage" | "ProfilePage" | "WebPage";
 
 interface PageSchemaInput {
   type: PageSchemaType;

--- a/src/pages/de/projekte.astro
+++ b/src/pages/de/projekte.astro
@@ -1,0 +1,5 @@
+---
+import ProjectIndexPage from "../../components/pages/ProjectIndexPage.astro";
+---
+
+<ProjectIndexPage locale="de" />

--- a/src/pages/en/projects.astro
+++ b/src/pages/en/projects.astro
@@ -1,0 +1,5 @@
+---
+import ProjectIndexPage from "../../components/pages/ProjectIndexPage.astro";
+---
+
+<ProjectIndexPage locale="en" />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -19,6 +19,7 @@ import {
   createStickerLayout,
   createTechnologyCollections,
 } from "../lib/portfolio";
+import { PROJECT_ROUTES } from "../data/project-content";
 
 const locale = detectLocale(Astro.request);
 const copy = tr(locale).portfolio;
@@ -63,6 +64,7 @@ const linkedinUrl =
         heading={copy.projects}
         finny={copy.finny}
         ventry={copy.ventry}
+        projectIndexPath={PROJECT_ROUTES[locale].index}
       />
       <WaveDivider />
       <TechnologiesSection

--- a/src/styles/features/projects.css
+++ b/src/styles/features/projects.css
@@ -1,0 +1,153 @@
+.project-index-shell {
+  min-height: 100vh;
+}
+.project-index-main {
+  width: 100%;
+  max-width: 42rem;
+  margin: 0 auto;
+  padding: 144px 24px;
+}
+.project-page-back {
+  display: inline-flex;
+  min-height: 34px;
+  align-items: center;
+  gap: 5px;
+  color: var(--text-secondary);
+  font-size: 13px;
+  font-weight: 500;
+}
+.project-page-back svg,
+.project-index-external svg {
+  width: 16px;
+  height: 16px;
+}
+.project-index-header {
+  margin-top: 42px;
+}
+.project-index-eyebrow {
+  margin: 0 0 10px;
+  color: var(--text-tertiary);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.project-index-header h1 {
+  max-width: 16ch;
+  margin: 0;
+  color: var(--text);
+  font-size: clamp(2rem, 7vw, 3.25rem);
+  font-weight: 500;
+  letter-spacing: -0.045em;
+  line-height: 1.05;
+}
+.project-index-header > p:last-child {
+  max-width: 60ch;
+  margin: 20px 0 0;
+  color: var(--text-secondary);
+  font-size: 17px;
+  line-height: 1.65;
+}
+.project-index-list {
+  display: grid;
+  gap: 18px;
+  margin-top: 56px;
+}
+.project-index-card {
+  scroll-margin-top: 96px;
+  padding: 24px;
+  border: 1px solid var(--divider);
+  border-radius: 18px;
+  background: var(--surface);
+  box-shadow: var(--shadow-border);
+}
+.project-index-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-tertiary);
+  font-size: 12px;
+  line-height: 1.4;
+}
+.project-index-meta span + span::before {
+  margin-right: 8px;
+  color: var(--divider);
+  content: "·";
+}
+.project-index-card h2 {
+  margin: 14px 0 0;
+  color: var(--text);
+  font-size: 20px;
+  font-weight: 550;
+  letter-spacing: -0.025em;
+  line-height: 1.3;
+}
+.project-index-card > p {
+  margin: 10px 0 0;
+  color: var(--text-secondary);
+  font-size: 15px;
+  line-height: 1.6;
+}
+.project-index-card ul {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  margin: 20px 0 0;
+  padding: 0;
+  list-style: none;
+}
+.project-index-card li {
+  padding: 5px 9px;
+  border: 1px solid var(--divider);
+  border-radius: 999px;
+  background: var(--card-shell);
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1;
+}
+.project-index-external {
+  display: inline-flex;
+  min-height: 36px;
+  align-items: center;
+  gap: 4px;
+  margin-top: 18px;
+  color: var(--text);
+  font-size: 13px;
+  font-weight: 550;
+}
+.project-index-external:focus-visible,
+.project-page-back:focus-visible,
+.project-preview-heading-link:focus-visible {
+  border-radius: 4px;
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 3px;
+}
+.project-preview-heading-link {
+  text-decoration: underline;
+  text-decoration-color: transparent;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+  transition: text-decoration-color 150ms var(--ease-smooth-out);
+}
+.project-preview-heading-link:is(:hover, :focus-visible) {
+  text-decoration-color: currentColor;
+}
+@media (max-width: 520px) {
+  .project-index-main {
+    padding: 104px 20px 120px;
+  }
+  .project-index-header {
+    margin-top: 34px;
+  }
+  .project-index-header > p:last-child {
+    font-size: 16px;
+  }
+  .project-index-list {
+    margin-top: 40px;
+  }
+  .project-index-card {
+    padding: 20px;
+    border-radius: 15px;
+  }
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,6 +1,7 @@
 @import "tailwindcss";
 @import "./tokens.css";
 @import "./features/privacy.css";
+@import "./features/projects.css";
 
 * {
   box-sizing: border-box;


### PR DESCRIPTION
## Summary

- define stable English and German project index and case-study route conventions plus a reusable typed content model
- publish complete localized project indexes with canonical, hreflang, metadata, `CollectionPage` schema, sitemap and Lighthouse coverage
- link homepage project headings descriptively to their localized index entries while preserving external product CTAs
- document translation, evidence, media, structured-data and publishing rules without creating placeholder case studies or a language switcher

## Validation

- `bun run ci`
- desktop visual QA at 1440×1000
- mobile visual QA at 390×844

Closes #32
