### PR TITLE
feat(content): publish localized Finny case study

### DIFF
--- a/.lighthouserc.cjs
+++ b/.lighthouserc.cjs
@@ -15,6 +15,7 @@ module.exports = {
         "http://127.0.0.1:4327/de/datenschutz",
         "http://127.0.0.1:4327/en/projects",
         "http://127.0.0.1:4327/de/projekte",
+        "http://127.0.0.1:4327/en/projects/finny",
       ],
       numberOfRuns: 3,
       startServerCommand:

--- a/scripts/browser-smoke.mjs
+++ b/scripts/browser-smoke.mjs
@@ -109,9 +109,11 @@ try {
     "https://itsjan.dev/de",
     "https://itsjan.dev/de/datenschutz",
     "https://itsjan.dev/de/projekte",
+    "https://itsjan.dev/de/projekte/finny",
     "https://itsjan.dev/en",
     "https://itsjan.dev/en/privacy",
     "https://itsjan.dev/en/projects",
+    "https://itsjan.dev/en/projects/finny",
   ]);
 
   const legacyPrivacyResponse = await fetch(`${baseUrl}/privacy`, {
@@ -198,6 +200,71 @@ try {
     assert.equal(pageEntity.url, `https://itsjan.dev${path}`);
     assert.equal(pageEntity.inLanguage, language);
     assert.equal(pageEntity.author["@id"], "https://itsjan.dev/#person");
+  }
+
+  for (const [
+    path,
+    language,
+    alternate,
+    expectedTitle,
+    expectedDescription,
+  ] of [
+    [
+      "/en/projects/finny",
+      "en",
+      "/de/projekte/finny",
+      "Finny: turning receipts into timely warranty reminders",
+      "How Jan-Marlon Leibl builds Finny, a TypeScript, React and Next.js web app that turns receipts into reviewable records and warranty reminders.",
+    ],
+    [
+      "/de/projekte/finny",
+      "de",
+      "/en/projects/finny",
+      "Finny: Von Belegen zu rechtzeitigen Garantie-Erinnerungen",
+      "Wie Jan-Marlon Leibl Finny entwickelt: eine Web-App mit TypeScript, React und Next.js für prüfbare Belegdaten und rechtzeitige Garantie-Erinnerungen.",
+    ],
+  ]) {
+    const response = await fetch(`${baseUrl}${path}`);
+    const html = await response.text();
+    const schemaSource = html.match(
+      /<script type="application\/ld\+json">([^<]+)<\/script>/,
+    )?.[1];
+    assert.equal(response.status, 200);
+    assert.ok(schemaSource);
+    assert.ok(html.includes(`<html lang="${language}"`));
+    assert.ok(
+      html.includes(`rel="canonical" href="https://itsjan.dev${path}"`),
+    );
+    assert.ok(
+      html.includes(
+        `hreflang="${language === "en" ? "de" : "en"}" href="https://itsjan.dev${alternate}"`,
+      ),
+    );
+    assert.ok(
+      html.includes(
+        `hreflang="x-default" href="https://itsjan.dev/en/projects/finny"`,
+      ),
+    );
+    assert.ok(
+      html.includes(
+        `<meta name="description" content="${expectedDescription}"`,
+      ),
+    );
+    assert.ok(html.includes(expectedTitle));
+    const article = JSON.parse(schemaSource)["@graph"].find(
+      (entity) => entity["@type"] === "Article",
+    );
+    assert.equal(article.url, `https://itsjan.dev${path}`);
+    assert.equal(article.inLanguage, language);
+    assert.equal(article.author["@id"], "https://itsjan.dev/#person");
+    assert.equal(article.datePublished, "2026-08-18");
+    assert.equal(article.dateModified, "2026-08-18");
+    assert.equal(article.image, "https://itsjan.dev/og.png");
+    assert.deepEqual(article.about, {
+      "@type": "SoftwareApplication",
+      name: "Finny",
+      url: "https://fnny.app",
+    });
   }
 
   const staticImageResponse = await fetch(`${baseUrl}/favicon.png`);
@@ -367,12 +434,12 @@ try {
     "Ventry expiring file sharing",
   ]);
   const semanticPage = await context.newPage();
-  for (const [path, expectedH1, expectedProjects, projectIndexPath] of [
+  for (const [path, expectedH1, expectedProjects, expectedProjectPaths] of [
     [
       "/en",
       "Jan-Marlon Leibl, software developer from Bremen",
       ["Finny receipt and warranty app", "Ventry expiring file sharing"],
-      "/en/projects",
+      ["/en/projects/finny", "/en/projects#ventry"],
     ],
     [
       "/de",
@@ -381,7 +448,7 @@ try {
         "Finny für Belege und Garantien",
         "Ventry für zeitlich begrenzte Dateifreigaben",
       ],
-      "/de/projekte",
+      ["/de/projekte/finny", "/de/projekte#ventry"],
     ],
   ]) {
     await semanticPage.goto(`${baseUrl}${path}`);
@@ -400,7 +467,7 @@ try {
       await semanticPage
         .locator("#projects h3 a")
         .evaluateAll((links) => links.map((link) => link.getAttribute("href"))),
-      [`${projectIndexPath}#finny`, `${projectIndexPath}#ventry`],
+      expectedProjectPaths,
     );
   }
   for (const [path, expectedH1, expectedProjectTitles] of [
@@ -431,11 +498,61 @@ try {
       await semanticPage.locator(".project-index-external").count(),
       2,
     );
+    assert.equal(
+      await semanticPage
+        .locator(".project-index-case-link")
+        .getAttribute("href"),
+      path === "/en/projects" ? "/en/projects/finny" : "/de/projekte/finny",
+    );
     assert.deepEqual(
       await semanticPage
         .locator(".project-index-external")
         .evaluateAll((links) => links.map((link) => link.getAttribute("href"))),
       ["https://fnny.app", "https://ventry.host"],
+    );
+  }
+  for (const [path, expectedH1, expectedSectionHeadings] of [
+    [
+      "/en/projects/finny",
+      "Finny: turning receipts into timely warranty reminders",
+      [
+        "The problem",
+        "My role",
+        "How the workflow is structured",
+        "Technologies used",
+        "Key decisions",
+        "Implementation challenges",
+        "Current outcome",
+      ],
+    ],
+    [
+      "/de/projekte/finny",
+      "Finny: Von Belegen zu rechtzeitigen Garantie-Erinnerungen",
+      [
+        "Das Problem",
+        "Meine Rolle",
+        "So ist der Ablauf aufgebaut",
+        "Eingesetzte Technologien",
+        "Wichtige Entscheidungen",
+        "Herausforderungen bei der Umsetzung",
+        "Aktueller Stand",
+      ],
+    ],
+  ]) {
+    await semanticPage.goto(`${baseUrl}${path}`);
+    assert.equal(await semanticPage.locator("h1").textContent(), expectedH1);
+    assert.deepEqual(
+      await semanticPage
+        .locator(".project-case-section > h2")
+        .allTextContents(),
+      expectedSectionHeadings,
+    );
+    assert.equal(await semanticPage.locator(".project-flow li").count(), 4);
+    assert.equal(
+      await semanticPage
+        .locator(".project-case-product-link")
+        .getAttribute("href"),
+      "https://fnny.app",
     );
   }
   await semanticPage.close();

--- a/src/components/home/ProjectsSection.astro
+++ b/src/components/home/ProjectsSection.astro
@@ -2,7 +2,7 @@
 import { Image } from "astro:assets";
 import finnyFavicon from "../../assets/finny-favicon.png";
 import ventryLogo from "../../assets/ventry-logo-white-56.png";
-import { PROJECTS } from "../../data/portfolio";
+import { PROJECTS, type ProjectId } from "../../data/portfolio";
 import type { PortfolioCopy } from "../../lib/i18n";
 import InteractiveLink from "../InteractiveLink.astro";
 
@@ -10,10 +10,10 @@ interface Props {
   heading: string;
   finny: PortfolioCopy["finny"];
   ventry: PortfolioCopy["ventry"];
-  projectIndexPath: string;
+  projectPaths: Record<ProjectId, string>;
 }
 
-const { heading, finny, ventry, projectIndexPath } = Astro.props;
+const { heading, finny, ventry, projectPaths } = Astro.props;
 ---
 
 <section id="projects">
@@ -53,7 +53,7 @@ const { heading, finny, ventry, projectIndexPath } = Astro.props;
           >
             <a
               class="project-preview-heading-link"
-              href={`${projectIndexPath}#${finny.id}`}>{finny.heading}</a
+              href={projectPaths[finny.id]}>{finny.heading}</a
             >
           </h3>
           <p
@@ -147,7 +147,7 @@ const { heading, finny, ventry, projectIndexPath } = Astro.props;
           >
             <a
               class="project-preview-heading-link"
-              href={`${projectIndexPath}#${ventry.id}`}>{ventry.heading}</a
+              href={projectPaths[ventry.id]}>{ventry.heading}</a
             >
           </h3>
           <p

--- a/src/components/pages/ProjectCaseStudyPage.astro
+++ b/src/components/pages/ProjectCaseStudyPage.astro
@@ -1,0 +1,188 @@
+---
+import {
+  PROJECT_INDEX_CONTENT,
+  PROJECT_ROUTES,
+  type ProjectCaseStudy,
+} from "../../data/project-content";
+import { ALL_TECHNOLOGIES } from "../../data/technologies";
+import Layout from "../../layouts/Layout.astro";
+import EdgeBlur from "../EdgeBlur.astro";
+import InteractiveLink from "../InteractiveLink.astro";
+import ArrowIcon from "../icons/ArrowIcon.astro";
+
+interface Props {
+  content: ProjectCaseStudy;
+}
+
+const { content } = Astro.props;
+const indexContent = PROJECT_INDEX_CONTENT[content.locale];
+const indexRoute = PROJECT_ROUTES[content.locale].index;
+const technologyNames = new Map(
+  ALL_TECHNOLOGIES.map(({ id, name }) => [id, name]),
+);
+const alternatePaths = {
+  en: content.locale === "en" ? content.route : content.alternateRoute,
+  de: content.locale === "de" ? content.route : content.alternateRoute,
+  "x-default": content.locale === "en" ? content.route : content.alternateRoute,
+};
+---
+
+<Layout
+  title={content.metaTitle}
+  description={content.metaDescription}
+  {alternatePaths}
+  schemaType="Article"
+  schemaAbout={{ name: content.productName, url: content.externalUrl }}
+  schemaPublishedAt={content.publishedAt}
+>
+  <div class="project-case-shell">
+    <EdgeBlur />
+    <EdgeBlur edge="bottom" />
+    <main class="project-case-main">
+      <InteractiveLink
+        variant="text"
+        class="hero-project-link project-page-back"
+        href={indexRoute}
+      >
+        <ArrowIcon direction="left" />
+        <span>{content.backLabel}</span>
+      </InteractiveLink>
+
+      <header class="project-case-header">
+        <p class="project-index-eyebrow">{content.eyebrow}</p>
+        <div class="project-index-meta">
+          <span>{content.period}</span>
+          <span>{content.status}</span>
+        </div>
+        <h1>{content.title}</h1>
+        <p>{content.summary}</p>
+        <InteractiveLink
+          variant="primary"
+          class="project-case-product-link"
+          href={content.externalUrl}
+          target="_blank"
+          rel="noreferrer"
+        >
+          {content.externalLabel}
+          <ArrowIcon direction="external" />
+        </InteractiveLink>
+      </header>
+
+      {
+        content.visuals.map((visual) =>
+          visual.kind === "diagram" ? (
+            <figure class="project-flow">
+              <figcaption>
+                <strong>{visual.title}</strong>
+                <span>{visual.description}</span>
+              </figcaption>
+              <ol>
+                {visual.steps.map((step, index) => (
+                  <li>
+                    <span aria-hidden="true">
+                      {String(index + 1).padStart(2, "0")}
+                    </span>
+                    <strong>{step}</strong>
+                  </li>
+                ))}
+              </ol>
+            </figure>
+          ) : (
+            <figure class="project-case-image">
+              <img
+                src={visual.src}
+                alt={visual.alt}
+                width={visual.width}
+                height={visual.height}
+                loading="lazy"
+                decoding="async"
+              />
+            </figure>
+          ),
+        )
+      }
+
+      <section class="project-case-section">
+        <h2>{content.labels.problem}</h2>
+        {content.problem.map((paragraph) => <p>{paragraph}</p>)}
+      </section>
+
+      <section class="project-case-section">
+        <h2>{content.labels.role}</h2>
+        {content.role.map((paragraph) => <p>{paragraph}</p>)}
+      </section>
+
+      <section class="project-case-section">
+        <h2>{content.labels.architecture}</h2>
+        <ol class="project-case-numbered-list">
+          {content.architecture.map((item) => <li>{item}</li>)}
+        </ol>
+      </section>
+
+      <section class="project-case-section">
+        <h2>{content.technologyLabel}</h2>
+        <ul
+          class="project-case-technologies"
+          aria-label={content.technologyLabel}
+        >
+          {
+            content.technologies.map((technologyId) => (
+              <li>{technologyNames.get(technologyId)}</li>
+            ))
+          }
+        </ul>
+      </section>
+
+      <section class="project-case-section">
+        <h2>{content.labels.decisions}</h2>
+        <div class="project-case-detail-grid">
+          {
+            content.decisions.map((decision) => (
+              <article>
+                <h3>{decision.title}</h3>
+                <p>{decision.detail}</p>
+              </article>
+            ))
+          }
+        </div>
+      </section>
+
+      <section class="project-case-section">
+        <h2>{content.labels.challenges}</h2>
+        <div class="project-case-detail-grid">
+          {
+            content.challenges.map((challenge) => (
+              <article>
+                <h3>{challenge.title}</h3>
+                <p>{challenge.detail}</p>
+              </article>
+            ))
+          }
+        </div>
+      </section>
+
+      <section class="project-case-section">
+        <h2>{content.labels.outcomes}</h2>
+        <ul class="project-case-outcomes">
+          {content.outcomes.map((outcome) => <li>{outcome}</li>)}
+        </ul>
+      </section>
+
+      <nav class="project-case-footer" aria-label={indexContent.title}>
+        <InteractiveLink variant="text" href={indexRoute}>
+          <ArrowIcon direction="left" />
+          {content.backLabel}
+        </InteractiveLink>
+        <InteractiveLink
+          variant="text"
+          href={content.externalUrl}
+          target="_blank"
+          rel="noreferrer"
+        >
+          {content.externalLabel}
+          <ArrowIcon direction="external" />
+        </InteractiveLink>
+      </nav>
+    </main>
+  </div>
+</Layout>

--- a/src/components/pages/ProjectIndexPage.astro
+++ b/src/components/pages/ProjectIndexPage.astro
@@ -5,6 +5,7 @@ import ArrowIcon from "../icons/ArrowIcon.astro";
 import {
   PROJECT_INDEX_CONTENT,
   PROJECT_ROUTES,
+  type ProjectIndexContent,
 } from "../../data/project-content";
 import { ALL_TECHNOLOGIES } from "../../data/technologies";
 import Layout from "../../layouts/Layout.astro";
@@ -15,7 +16,7 @@ interface Props {
 }
 
 const { locale } = Astro.props;
-const content = PROJECT_INDEX_CONTENT[locale];
+const content: ProjectIndexContent = PROJECT_INDEX_CONTENT[locale];
 const alternatePaths = {
   en: PROJECT_ROUTES.en.index,
   de: PROJECT_ROUTES.de.index,
@@ -66,16 +67,28 @@ const technologyNames = new Map(
                   <li>{technologyNames.get(technologyId)}</li>
                 ))}
               </ul>
-              <InteractiveLink
-                variant="text"
-                class="project-index-external"
-                href={project.externalUrl}
-                target="_blank"
-                rel="noreferrer"
-              >
-                <span>{project.externalLabel}</span>
-                <ArrowIcon direction="external" />
-              </InteractiveLink>
+              <div class="project-index-actions">
+                {project.caseStudyUrl && project.caseStudyLabel && (
+                  <InteractiveLink
+                    variant="text"
+                    class="project-index-case-link"
+                    href={project.caseStudyUrl}
+                  >
+                    <span>{project.caseStudyLabel}</span>
+                    <ArrowIcon />
+                  </InteractiveLink>
+                )}
+                <InteractiveLink
+                  variant="text"
+                  class="project-index-external"
+                  href={project.externalUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  <span>{project.externalLabel}</span>
+                  <ArrowIcon direction="external" />
+                </InteractiveLink>
+              </div>
             </article>
           ))
         }

--- a/src/data/project-content.test.ts
+++ b/src/data/project-content.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { PROJECT_INDEX_CONTENT, PROJECT_ROUTES } from "./project-content";
+import {
+  FINNY_CASE_STUDIES,
+  PROJECT_INDEX_CONTENT,
+  PROJECT_ROUTES,
+} from "./project-content";
 
 describe("localized project content architecture", () => {
   test("uses stable, distinct route conventions", () => {
@@ -35,6 +39,34 @@ describe("localized project content architecture", () => {
       expect(project.summary).toBeTruthy();
       expect(project.technologies.length).toBeGreaterThan(0);
       expect(project.externalUrl).toMatch(/^https:\/\//);
+    }
+  });
+
+  test("keeps both Finny case studies complete and genuinely localized", () => {
+    const english = FINNY_CASE_STUDIES.en;
+    const german = FINNY_CASE_STUDIES.de;
+
+    expect(english.route).toBe(PROJECT_ROUTES.en.finny);
+    expect(german.route).toBe(PROJECT_ROUTES.de.finny);
+    expect(english.alternateRoute).toBe(german.route);
+    expect(german.alternateRoute).toBe(english.route);
+    expect(english.metaDescription.length).toBeGreaterThanOrEqual(120);
+    expect(english.metaDescription.length).toBeLessThanOrEqual(160);
+    expect(german.metaDescription.length).toBeGreaterThanOrEqual(120);
+    expect(german.metaDescription.length).toBeLessThanOrEqual(160);
+    expect(english.summary).not.toBe(german.summary);
+
+    for (const caseStudy of [english, german]) {
+      expect(caseStudy.problem.length).toBeGreaterThan(0);
+      expect(caseStudy.role.length).toBeGreaterThan(0);
+      expect(caseStudy.architecture.length).toBeGreaterThan(0);
+      expect(caseStudy.technologies).toEqual(["typescript", "react", "nextjs"]);
+      expect(caseStudy.decisions.length).toBeGreaterThan(0);
+      expect(caseStudy.challenges.length).toBeGreaterThan(0);
+      expect(caseStudy.outcomes.length).toBeGreaterThan(0);
+      expect(caseStudy.visuals).toEqual([
+        expect.objectContaining({ kind: "diagram" }),
+      ]);
     }
   });
 });

--- a/src/data/project-content.ts
+++ b/src/data/project-content.ts
@@ -32,6 +32,7 @@ export type ProjectVisual =
 
 export interface ProjectCaseStudy {
   id: ProjectId;
+  productName: string;
   locale: Locale;
   route: string;
   alternateRoute: string;
@@ -39,9 +40,22 @@ export interface ProjectCaseStudy {
   title: string;
   metaTitle: string;
   metaDescription: string;
+  publishedAt: string;
   summary: string;
   period: string;
   status: string;
+  eyebrow: string;
+  backLabel: string;
+  externalLabel: string;
+  technologyLabel: string;
+  labels: {
+    problem: string;
+    role: string;
+    architecture: string;
+    decisions: string;
+    challenges: string;
+    outcomes: string;
+  };
   problem: readonly string[];
   role: readonly string[];
   architecture: readonly string[];
@@ -61,6 +75,8 @@ interface ProjectIndexEntry {
   technologies: readonly TechnologyId[];
   externalUrl: string;
   externalLabel: string;
+  caseStudyUrl?: string;
+  caseStudyLabel?: string;
 }
 
 export interface ProjectIndexContent {
@@ -96,6 +112,8 @@ export const PROJECT_INDEX_CONTENT = {
         technologies: ["typescript", "react", "nextjs"],
         externalUrl: PROJECTS.finny.href,
         externalLabel: "Visit Finny",
+        caseStudyUrl: PROJECT_ROUTES.en.finny,
+        caseStudyLabel: "Read the Finny case study",
       },
       {
         id: "ventry",
@@ -131,6 +149,8 @@ export const PROJECT_INDEX_CONTENT = {
         technologies: ["typescript", "react", "nextjs"],
         externalUrl: PROJECTS.finny.href,
         externalLabel: "Finny besuchen",
+        caseStudyUrl: PROJECT_ROUTES.de.finny,
+        caseStudyLabel: "Finny-Fallstudie lesen",
       },
       {
         id: "ventry",
@@ -146,3 +166,188 @@ export const PROJECT_INDEX_CONTENT = {
     ],
   },
 } as const satisfies Record<Locale, ProjectIndexContent>;
+
+export const FINNY_CASE_STUDIES = {
+  en: {
+    id: "finny",
+    productName: "Finny",
+    locale: "en",
+    route: PROJECT_ROUTES.en.finny,
+    alternateRoute: PROJECT_ROUTES.de.finny,
+    externalUrl: PROJECTS.finny.href,
+    title: "Finny: turning receipts into timely warranty reminders",
+    metaTitle: "Finny receipt and warranty app · Case study",
+    metaDescription:
+      "How Jan-Marlon Leibl builds Finny, a TypeScript, React and Next.js web app that turns receipts into reviewable records and warranty reminders.",
+    publishedAt: "2026-08-18",
+    summary:
+      "Finny is a web app for keeping proof of purchase, product details and warranty dates together. It turns receipt input into a record people can check before relying on its reminders.",
+    period: "Since 2026",
+    status: "Active development",
+    eyebrow: "Finny case study",
+    backLabel: "All projects",
+    externalLabel: "Visit Finny",
+    technologyLabel: "Technologies used",
+    labels: {
+      problem: "The problem",
+      role: "My role",
+      architecture: "How the workflow is structured",
+      decisions: "Key decisions",
+      challenges: "Implementation challenges",
+      outcomes: "Current outcome",
+    },
+    problem: [
+      "A receipt is most useful months after checkout, when a product fails or a warranty deadline approaches. By then, proof of purchase, product details and the relevant date are often no longer in the same place.",
+      "Finny brings those pieces into one reviewable record and keeps the saved warranty date connected to the receipt instead of treating the scan as an isolated document.",
+    ],
+    role: [
+      "I am building Finny as an active software project from Bremen. The documented project stack is TypeScript, React and Next.js.",
+      "My work covers the web product flow from receipt input and field review to the stored purchase record and the reminder experience.",
+    ],
+    architecture: [
+      "A receipt enters the web app as a photo or PDF; Pro users can also forward receipts by email.",
+      "OCR suggests the retailer, product, purchase date, price and warranty period. The user reviews and corrects those suggestions before saving them.",
+      "The reviewed record connects proof of purchase to a saved deadline. Finny then sends email reminders before that date.",
+    ],
+    technologies: ["typescript", "react", "nextjs"],
+    decisions: [
+      {
+        title: "Review before save",
+        detail:
+          "OCR output remains a draft. The product asks the user to verify the extracted fields before they become the record used for reminders.",
+      },
+      {
+        title: "One purchase record",
+        detail:
+          "The receipt, retailer, product, price, purchase date and warranty period stay connected instead of being spread across separate tools.",
+      },
+      {
+        title: "Deadline-led reminders",
+        detail:
+          "Reminders are derived from the reviewed warranty date, so the notification flow starts with data the user has already checked.",
+      },
+    ],
+    challenges: [
+      {
+        title: "Receipts are inconsistent inputs",
+        detail:
+          "Photos and PDFs vary, and extracted fields can be incomplete. The workflow therefore exposes suggestions for correction rather than presenting OCR as certain.",
+      },
+      {
+        title: "Dates are not legal conclusions",
+        detail:
+          "Commercial warranties and statutory rights are different. Finny organizes reviewable dates and reminders without deciding legal questions for the user.",
+      },
+    ],
+    outcomes: [
+      "Finny is an active project and has been part of the portfolio since 2026.",
+      "The public product supports receipt photos or PDFs, reviewable OCR fields and email reminders before saved deadlines.",
+      "Public product information is available in both English and German.",
+    ],
+    visuals: [
+      {
+        kind: "diagram",
+        title: "From receipt to reminder",
+        description:
+          "The Finny workflow keeps a human review between automatic receipt extraction and the saved deadline used for reminders.",
+        steps: [
+          "Add receipt",
+          "Review OCR draft",
+          "Save purchase record",
+          "Receive reminder",
+        ],
+      },
+    ],
+  },
+  de: {
+    id: "finny",
+    productName: "Finny",
+    locale: "de",
+    route: PROJECT_ROUTES.de.finny,
+    alternateRoute: PROJECT_ROUTES.en.finny,
+    externalUrl: PROJECTS.finny.href,
+    title: "Finny: Von Belegen zu rechtzeitigen Garantie-Erinnerungen",
+    metaTitle: "Finny für Belege und Garantien · Fallstudie",
+    metaDescription:
+      "Wie Jan-Marlon Leibl Finny entwickelt: eine Web-App mit TypeScript, React und Next.js für prüfbare Belegdaten und rechtzeitige Garantie-Erinnerungen.",
+    publishedAt: "2026-08-18",
+    summary:
+      "Finny ist eine Web-App, die Kaufbelege, Produktdetails und Garantiedaten zusammenhält. Aus einem Beleg entsteht ein Datensatz, den Nutzer prüfen, bevor sie sich auf die Erinnerungen verlassen.",
+    period: "Seit 2026",
+    status: "Aktive Entwicklung",
+    eyebrow: "Finny-Fallstudie",
+    backLabel: "Alle Projekte",
+    externalLabel: "Finny besuchen",
+    technologyLabel: "Eingesetzte Technologien",
+    labels: {
+      problem: "Das Problem",
+      role: "Meine Rolle",
+      architecture: "So ist der Ablauf aufgebaut",
+      decisions: "Wichtige Entscheidungen",
+      challenges: "Herausforderungen bei der Umsetzung",
+      outcomes: "Aktueller Stand",
+    },
+    problem: [
+      "Ein Kassenbon wird oft erst Monate nach dem Kauf wichtig, wenn ein Produkt ausfällt oder eine Garantiefrist näher rückt. Dann liegen Kaufnachweis, Produktdetails und das relevante Datum häufig nicht mehr am selben Ort.",
+      "Finny führt diese Informationen in einem prüfbaren Datensatz zusammen und verbindet das gespeicherte Garantiedatum direkt mit dem Beleg.",
+    ],
+    role: [
+      "Ich entwickle Finny als aktives Softwareprojekt aus Bremen. Als Projekt-Stack sind TypeScript, React und Next.js dokumentiert.",
+      "Meine Arbeit umfasst den Web-Ablauf von der Belegerfassung und Feldprüfung bis zum gespeicherten Kaufdatensatz und den Erinnerungen.",
+    ],
+    architecture: [
+      "Ein Beleg gelangt als Foto oder PDF in die Web-App; Pro-Nutzer können Belege zusätzlich per E-Mail weiterleiten.",
+      "Die OCR schlägt Händler, Produkt, Kaufdatum, Preis und Garantiezeitraum vor. Vor dem Speichern prüft und korrigiert der Nutzer diese Angaben.",
+      "Der geprüfte Datensatz verbindet den Kaufnachweis mit einer gespeicherten Frist. Vor diesem Datum verschickt Finny Erinnerungen per E-Mail.",
+    ],
+    technologies: ["typescript", "react", "nextjs"],
+    decisions: [
+      {
+        title: "Prüfung vor dem Speichern",
+        detail:
+          "Das OCR-Ergebnis bleibt ein Entwurf. Nutzer bestätigen oder korrigieren die erkannten Felder, bevor daraus die Grundlage für Erinnerungen wird.",
+      },
+      {
+        title: "Ein Datensatz pro Kauf",
+        detail:
+          "Beleg, Händler, Produkt, Preis, Kaufdatum und Garantiezeitraum bleiben verbunden, statt auf mehrere Werkzeuge verteilt zu sein.",
+      },
+      {
+        title: "Erinnerungen aus geprüften Fristen",
+        detail:
+          "Die Benachrichtigungen leiten sich aus dem kontrollierten Garantiedatum ab und beginnen damit bei Daten, die der Nutzer bereits geprüft hat.",
+      },
+    ],
+    challenges: [
+      {
+        title: "Belege sind uneinheitliche Eingaben",
+        detail:
+          "Fotos und PDFs unterscheiden sich, erkannte Felder können unvollständig sein. Deshalb zeigt der Ablauf korrigierbare Vorschläge, statt OCR-Ergebnisse als sicher darzustellen.",
+      },
+      {
+        title: "Fristen sind keine Rechtsauskunft",
+        detail:
+          "Herstellergarantien und gesetzliche Rechte sind nicht dasselbe. Finny organisiert prüfbare Daten und Erinnerungen, ohne Rechtsfragen für den Nutzer zu entscheiden.",
+      },
+    ],
+    outcomes: [
+      "Finny ist ein aktives Projekt und seit 2026 Teil des Portfolios.",
+      "Das öffentliche Produkt unterstützt Belegfotos oder PDFs, prüfbare OCR-Felder und E-Mail-Erinnerungen vor gespeicherten Fristen.",
+      "Öffentliche Produktinformationen stehen auf Deutsch und Englisch bereit.",
+    ],
+    visuals: [
+      {
+        kind: "diagram",
+        title: "Vom Beleg zur Erinnerung",
+        description:
+          "Im Finny-Ablauf liegt eine menschliche Prüfung zwischen der automatischen Belegerkennung und der gespeicherten Frist für Erinnerungen.",
+        steps: [
+          "Beleg hinzufügen",
+          "OCR-Entwurf prüfen",
+          "Kaufdatensatz speichern",
+          "Erinnerung erhalten",
+        ],
+      },
+    ],
+  },
+} as const satisfies Record<Locale, ProjectCaseStudy>;

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -25,6 +25,8 @@ interface Props {
   alternatePaths?: Partial<Record<Locale | "x-default", string>>;
   markdownPath?: string;
   schemaType?: PageSchemaType;
+  schemaAbout?: { name: string; url: string };
+  schemaPublishedAt?: string;
 }
 
 const props: Props = Astro.props;
@@ -58,6 +60,8 @@ const pageSchema = buildPageSchema({
   title,
   description,
   locale,
+  about: props.schemaAbout,
+  publishedAt: props.schemaPublishedAt,
 });
 
 if (requestUrl.pathname === "/" || requestUrl.pathname === "") {

--- a/src/lib/schema.test.ts
+++ b/src/lib/schema.test.ts
@@ -62,4 +62,30 @@ describe("buildPageSchema", () => {
       });
     }
   });
+
+  test("describes the software covered by a case-study article", () => {
+    const schema = buildPageSchema({
+      type: "Article",
+      url: "https://itsjan.dev/en/projects/finny",
+      title: "Finny case study",
+      description: "How Finny works.",
+      locale: "en",
+      about: { name: "Finny", url: "https://fnny.app" },
+      publishedAt: "2026-08-18",
+    });
+    const article = schema["@graph"][2];
+
+    expect(article).toMatchObject({
+      "@type": "Article",
+      headline: "Finny case study",
+      image: "https://itsjan.dev/og.png",
+      datePublished: "2026-08-18",
+      dateModified: "2026-08-18",
+      about: {
+        "@type": "SoftwareApplication",
+        name: "Finny",
+        url: "https://fnny.app",
+      },
+    });
+  });
 });

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -1,6 +1,7 @@
 import type { Locale } from "./locale";
 import {
   CONTACT_EMAIL,
+  OPEN_GRAPH_IMAGE_URL,
   PERSON_NAME,
   PROFILE_IMAGE_URL,
   SITE_NAME,
@@ -17,6 +18,8 @@ interface PageSchemaInput {
   title: string;
   description: string;
   locale: Locale;
+  about?: { name: string; url: string };
+  publishedAt?: string;
 }
 
 export function buildPageSchema({
@@ -25,6 +28,8 @@ export function buildPageSchema({
   title,
   description,
   locale,
+  about,
+  publishedAt,
 }: PageSchemaInput) {
   const personId = `${SITE_ORIGIN}/#person`;
   const websiteId = `${SITE_ORIGIN}/#website`;
@@ -74,6 +79,24 @@ export function buildPageSchema({
         description,
         inLanguage: locale,
         isPartOf: { "@id": websiteId },
+        ...(about
+          ? {
+              about: {
+                "@type": "SoftwareApplication",
+                name: about.name,
+                url: about.url,
+              },
+            }
+          : {}),
+        ...(type === "Article"
+          ? {
+              headline: title,
+              image: OPEN_GRAPH_IMAGE_URL,
+              ...(publishedAt
+                ? { datePublished: publishedAt, dateModified: publishedAt }
+                : {}),
+            }
+          : {}),
         ...(type === "ProfilePage"
           ? { mainEntity: personReference }
           : { author: personReference }),

--- a/src/pages/de/projekte/finny.astro
+++ b/src/pages/de/projekte/finny.astro
@@ -1,0 +1,6 @@
+---
+import ProjectCaseStudyPage from "../../../components/pages/ProjectCaseStudyPage.astro";
+import { FINNY_CASE_STUDIES } from "../../../data/project-content";
+---
+
+<ProjectCaseStudyPage content={FINNY_CASE_STUDIES.de} />

--- a/src/pages/en/projects/finny.astro
+++ b/src/pages/en/projects/finny.astro
@@ -1,0 +1,6 @@
+---
+import ProjectCaseStudyPage from "../../../components/pages/ProjectCaseStudyPage.astro";
+import { FINNY_CASE_STUDIES } from "../../../data/project-content";
+---
+
+<ProjectCaseStudyPage content={FINNY_CASE_STUDIES.en} />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -64,7 +64,10 @@ const linkedinUrl =
         heading={copy.projects}
         finny={copy.finny}
         ventry={copy.ventry}
-        projectIndexPath={PROJECT_ROUTES[locale].index}
+        projectPaths={{
+          finny: PROJECT_ROUTES[locale].finny,
+          ventry: `${PROJECT_ROUTES[locale].index}#ventry`,
+        }}
       />
       <WaveDivider />
       <TechnologiesSection

--- a/src/styles/features/projects.css
+++ b/src/styles/features/projects.css
@@ -17,7 +17,10 @@
   font-weight: 500;
 }
 .project-page-back svg,
-.project-index-external svg {
+.project-index-external svg,
+.project-index-case-link svg,
+.project-case-product-link svg,
+.project-case-footer svg {
   width: 16px;
   height: 16px;
 }
@@ -106,17 +109,24 @@
   font-size: 12px;
   line-height: 1;
 }
+.project-index-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 20px;
+  margin-top: 18px;
+}
+.project-index-case-link,
 .project-index-external {
   display: inline-flex;
   min-height: 36px;
   align-items: center;
   gap: 4px;
-  margin-top: 18px;
   color: var(--text);
   font-size: 13px;
   font-weight: 550;
 }
 .project-index-external:focus-visible,
+.project-index-case-link:focus-visible,
 .project-page-back:focus-visible,
 .project-preview-heading-link:focus-visible {
   border-radius: 4px;
@@ -132,6 +142,239 @@
 }
 .project-preview-heading-link:is(:hover, :focus-visible) {
   text-decoration-color: currentColor;
+}
+.project-case-shell {
+  min-height: 100vh;
+}
+.project-case-main {
+  width: 100%;
+  max-width: 46rem;
+  margin: 0 auto;
+  padding: 144px 24px;
+}
+.project-case-header {
+  margin-top: 42px;
+}
+.project-case-header .project-index-meta {
+  margin-bottom: 16px;
+}
+.project-case-header h1 {
+  max-width: 18ch;
+  margin: 0;
+  color: var(--text);
+  font-size: clamp(2.25rem, 7vw, 3.75rem);
+  font-weight: 500;
+  letter-spacing: -0.05em;
+  line-height: 1.02;
+}
+.project-case-header > p:not(.project-index-eyebrow) {
+  max-width: 62ch;
+  margin: 22px 0 0;
+  color: var(--text-secondary);
+  font-size: 18px;
+  line-height: 1.65;
+}
+.project-case-product-link {
+  display: inline-flex;
+  min-height: 42px;
+  align-items: center;
+  gap: 4px;
+  margin-top: 24px;
+}
+.project-flow {
+  margin: 64px 0 0;
+  padding: 24px;
+  border: 1px solid var(--divider);
+  border-radius: 20px;
+  background: var(--card-shell);
+  box-shadow: var(--shadow-border);
+}
+.project-flow figcaption {
+  display: grid;
+  gap: 6px;
+}
+.project-flow figcaption strong {
+  color: var(--text);
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+}
+.project-flow figcaption span {
+  max-width: 64ch;
+  color: var(--text-secondary);
+  font-size: 14px;
+  line-height: 1.55;
+}
+.project-flow ol {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+  margin: 22px 0 0;
+  padding: 0;
+  list-style: none;
+}
+.project-flow li {
+  position: relative;
+  display: grid;
+  min-height: 104px;
+  align-content: space-between;
+  gap: 18px;
+  padding: 14px;
+  border: 1px solid var(--divider);
+  border-radius: 12px;
+  background: var(--surface);
+}
+.project-flow li:not(:last-child)::after {
+  position: absolute;
+  z-index: 1;
+  top: 50%;
+  right: -10px;
+  width: 12px;
+  border-top: 1px solid var(--text-tertiary);
+  content: "";
+}
+.project-flow li > span {
+  color: var(--text-tertiary);
+  font-family: "Geist Mono", monospace;
+  font-size: 11px;
+}
+.project-flow li > strong {
+  color: var(--text);
+  font-size: 13px;
+  font-weight: 550;
+  line-height: 1.35;
+}
+.project-case-image {
+  margin: 64px 0 0;
+}
+.project-case-image img {
+  display: block;
+  width: 100%;
+  height: auto;
+  border-radius: 20px;
+}
+.project-case-section {
+  margin-top: 72px;
+}
+.project-case-section h2 {
+  max-width: 22ch;
+  margin: 0 0 18px;
+  color: var(--text);
+  font-size: 26px;
+  font-weight: 550;
+  letter-spacing: -0.035em;
+  line-height: 1.15;
+}
+.project-case-section > p {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 16px;
+  line-height: 1.7;
+}
+.project-case-section > p + p {
+  margin-top: 14px;
+}
+.project-case-numbered-list,
+.project-case-outcomes {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.project-case-numbered-list {
+  counter-reset: case-step;
+}
+.project-case-numbered-list li,
+.project-case-outcomes li {
+  position: relative;
+  padding-left: 34px;
+  color: var(--text-secondary);
+  font-size: 15px;
+  line-height: 1.65;
+}
+.project-case-numbered-list li {
+  counter-increment: case-step;
+}
+.project-case-numbered-list li::before {
+  position: absolute;
+  top: 1px;
+  left: 0;
+  color: var(--text-tertiary);
+  content: counter(case-step, decimal-leading-zero);
+  font-family: "Geist Mono", monospace;
+  font-size: 11px;
+}
+.project-case-outcomes li::before {
+  position: absolute;
+  top: 0.68em;
+  left: 4px;
+  width: 12px;
+  border-top: 1px solid var(--text-tertiary);
+  content: "";
+}
+.project-case-technologies {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.project-case-technologies li {
+  padding: 7px 11px;
+  border: 1px solid var(--divider);
+  border-radius: 999px;
+  background: var(--card-shell);
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+.project-case-detail-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+.project-case-detail-grid article {
+  padding: 20px;
+  border: 1px solid var(--divider);
+  border-radius: 15px;
+  background: var(--surface);
+  box-shadow: var(--shadow-border);
+}
+.project-case-detail-grid article:first-child:last-child,
+.project-case-detail-grid article:last-child:nth-child(odd) {
+  grid-column: 1 / -1;
+}
+.project-case-detail-grid h3 {
+  margin: 0;
+  color: var(--text);
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+}
+.project-case-detail-grid p {
+  margin: 8px 0 0;
+  color: var(--text-secondary);
+  font-size: 14px;
+  line-height: 1.6;
+}
+.project-case-footer {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 80px;
+  padding-top: 24px;
+  border-top: 1px solid var(--divider);
+}
+.project-case-footer a {
+  display: inline-flex;
+  min-height: 36px;
+  align-items: center;
+  gap: 4px;
+  color: var(--text-secondary);
+  font-size: 13px;
+  font-weight: 550;
 }
 @media (max-width: 520px) {
   .project-index-main {
@@ -149,5 +392,50 @@
   .project-index-card {
     padding: 20px;
     border-radius: 15px;
+  }
+  .project-case-main {
+    padding: 104px 20px 120px;
+  }
+  .project-case-header {
+    margin-top: 34px;
+  }
+  .project-case-header > p:not(.project-index-eyebrow) {
+    font-size: 16px;
+  }
+  .project-flow {
+    margin-top: 48px;
+    padding: 18px;
+    border-radius: 16px;
+  }
+  .project-flow ol {
+    grid-template-columns: 1fr;
+  }
+  .project-flow li {
+    min-height: auto;
+    grid-template-columns: 28px 1fr;
+    align-items: center;
+    gap: 8px;
+  }
+  .project-flow li:not(:last-child)::after {
+    top: auto;
+    right: auto;
+    bottom: -10px;
+    left: 27px;
+    width: 1px;
+    height: 12px;
+    border-top: 0;
+    border-left: 1px solid var(--text-tertiary);
+  }
+  .project-case-section {
+    margin-top: 56px;
+  }
+  .project-case-detail-grid {
+    grid-template-columns: 1fr;
+  }
+  .project-case-detail-grid article:last-child:nth-child(odd) {
+    grid-column: auto;
+  }
+  .project-case-footer {
+    margin-top: 64px;
   }
 }


### PR DESCRIPTION
## Summary

- publish complete English and German Finny case studies covering the problem, Jan's role, workflow architecture, technologies, decisions, challenges and current status
- add an original accessible, responsive receipt-to-reminder process diagram and link the localized homepage and project index directly to each case study
- add localized metadata, canonical and reciprocal hreflang links, sitemap coverage and Article/SoftwareApplication structured data
- verify claims against the existing portfolio and Finny's public product resources without adding usage metrics or unsupported outcomes

## Validation

- `bun run ci`
- desktop visual QA at 1440×1000
- mobile visual QA at 390×844

Closes #39
