### PR TITLE
feat(content): publish localized Ventry case study

### DIFF
--- a/.lighthouserc.cjs
+++ b/.lighthouserc.cjs
@@ -16,6 +16,7 @@ module.exports = {
         "http://127.0.0.1:4327/en/projects",
         "http://127.0.0.1:4327/de/projekte",
         "http://127.0.0.1:4327/en/projects/finny",
+        "http://127.0.0.1:4327/en/projects/ventry",
       ],
       numberOfRuns: 3,
       startServerCommand:

--- a/scripts/browser-smoke.mjs
+++ b/scripts/browser-smoke.mjs
@@ -110,10 +110,12 @@ try {
     "https://itsjan.dev/de/datenschutz",
     "https://itsjan.dev/de/projekte",
     "https://itsjan.dev/de/projekte/finny",
+    "https://itsjan.dev/de/projekte/ventry",
     "https://itsjan.dev/en",
     "https://itsjan.dev/en/privacy",
     "https://itsjan.dev/en/projects",
     "https://itsjan.dev/en/projects/finny",
+    "https://itsjan.dev/en/projects/ventry",
   ]);
 
   const legacyPrivacyResponse = await fetch(`${baseUrl}/privacy`, {
@@ -206,22 +208,51 @@ try {
     path,
     language,
     alternate,
+    xDefault,
     expectedTitle,
     expectedDescription,
+    productName,
+    productUrl,
   ] of [
     [
       "/en/projects/finny",
       "en",
       "/de/projekte/finny",
+      "/en/projects/finny",
       "Finny: turning receipts into timely warranty reminders",
       "How Jan-Marlon Leibl builds Finny, a TypeScript, React and Next.js web app that turns receipts into reviewable records and warranty reminders.",
+      "Finny",
+      "https://fnny.app",
     ],
     [
       "/de/projekte/finny",
       "de",
       "/en/projects/finny",
+      "/en/projects/finny",
       "Finny: Von Belegen zu rechtzeitigen Garantie-Erinnerungen",
       "Wie Jan-Marlon Leibl Finny entwickelt: eine Web-App mit TypeScript, React und Next.js für prüfbare Belegdaten und rechtzeitige Garantie-Erinnerungen.",
+      "Finny",
+      "https://fnny.app",
+    ],
+    [
+      "/en/projects/ventry",
+      "en",
+      "/de/projekte/ventry",
+      "/en/projects/ventry",
+      "Ventry: file sharing with an expiry built in",
+      "How Jan-Marlon Leibl built Ventry with TypeScript and Next.js: a 2023–2024 file-sharing project with expiring links and automatic file removal.",
+      "Ventry",
+      "https://ventry.host",
+    ],
+    [
+      "/de/projekte/ventry",
+      "de",
+      "/en/projects/ventry",
+      "/en/projects/ventry",
+      "Ventry: Filesharing mit eingebautem Ablaufdatum",
+      "Wie Jan-Marlon Leibl Ventry mit TypeScript und Next.js entwickelte: ein Filesharing-Projekt von 2023–2024 mit ablaufenden Links und automatischer Dateilöschung.",
+      "Ventry",
+      "https://ventry.host",
     ],
   ]) {
     const response = await fetch(`${baseUrl}${path}`);
@@ -242,7 +273,7 @@ try {
     );
     assert.ok(
       html.includes(
-        `hreflang="x-default" href="https://itsjan.dev/en/projects/finny"`,
+        `hreflang="x-default" href="https://itsjan.dev${xDefault}"`,
       ),
     );
     assert.ok(
@@ -262,8 +293,8 @@ try {
     assert.equal(article.image, "https://itsjan.dev/og.png");
     assert.deepEqual(article.about, {
       "@type": "SoftwareApplication",
-      name: "Finny",
-      url: "https://fnny.app",
+      name: productName,
+      url: productUrl,
     });
   }
 
@@ -439,7 +470,7 @@ try {
       "/en",
       "Jan-Marlon Leibl, software developer from Bremen",
       ["Finny receipt and warranty app", "Ventry expiring file sharing"],
-      ["/en/projects/finny", "/en/projects#ventry"],
+      ["/en/projects/finny", "/en/projects/ventry"],
     ],
     [
       "/de",
@@ -448,7 +479,7 @@ try {
         "Finny für Belege und Garantien",
         "Ventry für zeitlich begrenzte Dateifreigaben",
       ],
-      ["/de/projekte/finny", "/de/projekte#ventry"],
+      ["/de/projekte/finny", "/de/projekte/ventry"],
     ],
   ]) {
     await semanticPage.goto(`${baseUrl}${path}`);
@@ -498,11 +529,13 @@ try {
       await semanticPage.locator(".project-index-external").count(),
       2,
     );
-    assert.equal(
+    assert.deepEqual(
       await semanticPage
         .locator(".project-index-case-link")
-        .getAttribute("href"),
-      path === "/en/projects" ? "/en/projects/finny" : "/de/projekte/finny",
+        .evaluateAll((links) => links.map((link) => link.getAttribute("href"))),
+      path === "/en/projects"
+        ? ["/en/projects/finny", "/en/projects/ventry"]
+        : ["/de/projekte/finny", "/de/projekte/ventry"],
     );
     assert.deepEqual(
       await semanticPage
@@ -511,7 +544,7 @@ try {
       ["https://fnny.app", "https://ventry.host"],
     );
   }
-  for (const [path, expectedH1, expectedSectionHeadings] of [
+  for (const [path, expectedH1, expectedSectionHeadings, productUrl] of [
     [
       "/en/projects/finny",
       "Finny: turning receipts into timely warranty reminders",
@@ -524,6 +557,7 @@ try {
         "Implementation challenges",
         "Current outcome",
       ],
+      "https://fnny.app",
     ],
     [
       "/de/projekte/finny",
@@ -537,6 +571,35 @@ try {
         "Herausforderungen bei der Umsetzung",
         "Aktueller Stand",
       ],
+      "https://fnny.app",
+    ],
+    [
+      "/en/projects/ventry",
+      "Ventry: file sharing with an expiry built in",
+      [
+        "The problem",
+        "My role",
+        "How the lifecycle is structured",
+        "Technologies used",
+        "Key decisions",
+        "Implementation challenges",
+        "Project status",
+      ],
+      "https://ventry.host",
+    ],
+    [
+      "/de/projekte/ventry",
+      "Ventry: Filesharing mit eingebautem Ablaufdatum",
+      [
+        "Das Problem",
+        "Meine Rolle",
+        "So ist der Lebenszyklus aufgebaut",
+        "Eingesetzte Technologien",
+        "Wichtige Entscheidungen",
+        "Herausforderungen bei der Umsetzung",
+        "Projektstatus",
+      ],
+      "https://ventry.host",
     ],
   ]) {
     await semanticPage.goto(`${baseUrl}${path}`);
@@ -552,7 +615,7 @@ try {
       await semanticPage
         .locator(".project-case-product-link")
         .getAttribute("href"),
-      "https://fnny.app",
+      productUrl,
     );
   }
   await semanticPage.close();

--- a/src/data/project-content.test.ts
+++ b/src/data/project-content.test.ts
@@ -3,6 +3,7 @@ import {
   FINNY_CASE_STUDIES,
   PROJECT_INDEX_CONTENT,
   PROJECT_ROUTES,
+  VENTRY_CASE_STUDIES,
 } from "./project-content";
 
 describe("localized project content architecture", () => {
@@ -61,6 +62,35 @@ describe("localized project content architecture", () => {
       expect(caseStudy.role.length).toBeGreaterThan(0);
       expect(caseStudy.architecture.length).toBeGreaterThan(0);
       expect(caseStudy.technologies).toEqual(["typescript", "react", "nextjs"]);
+      expect(caseStudy.decisions.length).toBeGreaterThan(0);
+      expect(caseStudy.challenges.length).toBeGreaterThan(0);
+      expect(caseStudy.outcomes.length).toBeGreaterThan(0);
+      expect(caseStudy.visuals).toEqual([
+        expect.objectContaining({ kind: "diagram" }),
+      ]);
+    }
+  });
+
+  test("keeps both Ventry case studies complete, historical and localized", () => {
+    const english = VENTRY_CASE_STUDIES.en;
+    const german = VENTRY_CASE_STUDIES.de;
+
+    expect(english.route).toBe(PROJECT_ROUTES.en.ventry);
+    expect(german.route).toBe(PROJECT_ROUTES.de.ventry);
+    expect(english.alternateRoute).toBe(german.route);
+    expect(german.alternateRoute).toBe(english.route);
+    expect(english.metaDescription.length).toBeGreaterThanOrEqual(120);
+    expect(english.metaDescription.length).toBeLessThanOrEqual(160);
+    expect(german.metaDescription.length).toBeGreaterThanOrEqual(120);
+    expect(german.metaDescription.length).toBeLessThanOrEqual(160);
+    expect(english.summary).not.toBe(german.summary);
+
+    for (const caseStudy of [english, german]) {
+      expect(caseStudy.period).toBe("2023–2024");
+      expect(caseStudy.problem.length).toBeGreaterThan(0);
+      expect(caseStudy.role.length).toBeGreaterThan(0);
+      expect(caseStudy.architecture.length).toBeGreaterThan(0);
+      expect(caseStudy.technologies).toEqual(["typescript", "nextjs"]);
       expect(caseStudy.decisions.length).toBeGreaterThan(0);
       expect(caseStudy.challenges.length).toBeGreaterThan(0);
       expect(caseStudy.outcomes.length).toBeGreaterThan(0);

--- a/src/data/project-content.ts
+++ b/src/data/project-content.ts
@@ -125,6 +125,8 @@ export const PROJECT_INDEX_CONTENT = {
         technologies: ["typescript", "nextjs"],
         externalUrl: PROJECTS.ventry.href,
         externalLabel: "Visit Ventry",
+        caseStudyUrl: PROJECT_ROUTES.en.ventry,
+        caseStudyLabel: "Read the Ventry case study",
       },
     ],
   },
@@ -162,6 +164,8 @@ export const PROJECT_INDEX_CONTENT = {
         technologies: ["typescript", "nextjs"],
         externalUrl: PROJECTS.ventry.href,
         externalLabel: "Ventry besuchen",
+        caseStudyUrl: PROJECT_ROUTES.de.ventry,
+        caseStudyLabel: "Ventry-Fallstudie lesen",
       },
     ],
   },
@@ -346,6 +350,191 @@ export const FINNY_CASE_STUDIES = {
           "OCR-Entwurf prüfen",
           "Kaufdatensatz speichern",
           "Erinnerung erhalten",
+        ],
+      },
+    ],
+  },
+} as const satisfies Record<Locale, ProjectCaseStudy>;
+
+export const VENTRY_CASE_STUDIES = {
+  en: {
+    id: "ventry",
+    productName: "Ventry",
+    locale: "en",
+    route: PROJECT_ROUTES.en.ventry,
+    alternateRoute: PROJECT_ROUTES.de.ventry,
+    externalUrl: PROJECTS.ventry.href,
+    title: "Ventry: file sharing with an expiry built in",
+    metaTitle: "Ventry expiring file sharing · Case study",
+    metaDescription:
+      "How Jan-Marlon Leibl built Ventry with TypeScript and Next.js: a 2023–2024 file-sharing project with expiring links and automatic file removal.",
+    publishedAt: "2026-08-18",
+    summary:
+      "Ventry was developed from 2023 to 2024 around a direct promise: share a file through a link, give that link an expiry, and remove the file automatically when its time is up.",
+    period: "2023–2024",
+    status: "Historical development period",
+    eyebrow: "Ventry case study",
+    backLabel: "All projects",
+    externalLabel: "Visit Ventry",
+    technologyLabel: "Technologies used",
+    labels: {
+      problem: "The problem",
+      role: "My role",
+      architecture: "How the lifecycle is structured",
+      decisions: "Key decisions",
+      challenges: "Implementation challenges",
+      outcomes: "Project status",
+    },
+    problem: [
+      "Many file-sharing links outlive the moment they were created for. That leaves the sender responsible for remembering where a file is hosted and when it should no longer be available.",
+      "Ventry tied access to a defined expiry and paired that expiry with automatic file removal, so temporary sharing did not depend on a later manual cleanup step.",
+    ],
+    role: [
+      "I built Ventry from 2023 to 2024 as a TypeScript and Next.js project. The portfolio records that period as completed work rather than implying current development.",
+      "My work centered on the browser flow for uploading a file, creating a shareable link and making the expiry visible as part of the sharing lifecycle.",
+    ],
+    architecture: [
+      "The sender uploads a file and chooses the time window in which it should remain available.",
+      "Ventry creates a link that represents access to that file for the configured period.",
+      "Once the expiry is reached, link access ends and the associated file is removed automatically.",
+    ],
+    technologies: ["typescript", "nextjs"],
+    decisions: [
+      {
+        title: "Expiry belongs to the share",
+        detail:
+          "The lifetime is part of creating the link, not a separate cleanup preference that has to be remembered later.",
+      },
+      {
+        title: "Link and file share one lifecycle",
+        detail:
+          "An expired link and its stored file are treated as one state transition so access and retention do not drift apart.",
+      },
+      {
+        title: "Keep the browser flow direct",
+        detail:
+          "The core interaction stays focused on the file, its expiry and the resulting link rather than adding unrelated project-management features.",
+      },
+    ],
+    challenges: [
+      {
+        title: "Access and storage must agree",
+        detail:
+          "Ending access is only half of the promise. The stored file also has to follow the same expiry so a dead link does not leave forgotten data behind.",
+      },
+      {
+        title: "Cleanup happens without a page visit",
+        detail:
+          "Expiry is time-driven rather than triggered by the sender returning to the site, so removal cannot rely on a later manual interaction.",
+      },
+    ],
+    outcomes: [
+      "The portfolio records Ventry's development period as 2023 to 2024.",
+      "The implemented concept connected expiring links with automatic removal of the associated file.",
+      "The public ventry.host site remains online and currently describes self-deleting uploads; that does not imply that Jan is still developing the project.",
+    ],
+    visuals: [
+      {
+        kind: "diagram",
+        title: "A time-bounded file lifecycle",
+        description:
+          "The Ventry flow couples the link's availability with the lifetime of the stored file.",
+        steps: [
+          "Upload file",
+          "Set expiry",
+          "Share link",
+          "Remove automatically",
+        ],
+      },
+    ],
+  },
+  de: {
+    id: "ventry",
+    productName: "Ventry",
+    locale: "de",
+    route: PROJECT_ROUTES.de.ventry,
+    alternateRoute: PROJECT_ROUTES.en.ventry,
+    externalUrl: PROJECTS.ventry.href,
+    title: "Ventry: Filesharing mit eingebautem Ablaufdatum",
+    metaTitle: "Ventry für ablaufendes Filesharing · Fallstudie",
+    metaDescription:
+      "Wie Jan-Marlon Leibl Ventry mit TypeScript und Next.js entwickelte: ein Filesharing-Projekt von 2023–2024 mit ablaufenden Links und automatischer Dateilöschung.",
+    publishedAt: "2026-08-18",
+    summary:
+      "Ventry entstand von 2023 bis 2024 mit einem klaren Versprechen: Eine Datei über einen Link teilen, diesem Link ein Ablaufdatum geben und die Datei danach automatisch entfernen.",
+    period: "2023–2024",
+    status: "Historischer Entwicklungszeitraum",
+    eyebrow: "Ventry-Fallstudie",
+    backLabel: "Alle Projekte",
+    externalLabel: "Ventry besuchen",
+    technologyLabel: "Eingesetzte Technologien",
+    labels: {
+      problem: "Das Problem",
+      role: "Meine Rolle",
+      architecture: "So ist der Lebenszyklus aufgebaut",
+      decisions: "Wichtige Entscheidungen",
+      challenges: "Herausforderungen bei der Umsetzung",
+      outcomes: "Projektstatus",
+    },
+    problem: [
+      "Viele Filesharing-Links bleiben länger bestehen als der Anlass, für den sie erstellt wurden. Der Absender muss sich dann merken, wo eine Datei liegt und wann sie nicht mehr verfügbar sein sollte.",
+      "Ventry verband den Zugriff mit einem festen Ablaufdatum und koppelte diesen Zeitpunkt an die automatische Dateilöschung. Temporäres Teilen brauchte dadurch keinen späteren manuellen Aufräumschritt.",
+    ],
+    role: [
+      "Ich entwickelte Ventry von 2023 bis 2024 als Projekt mit TypeScript und Next.js. Das Portfolio führt diesen Zeitraum als abgeschlossene Arbeit und behauptet keine laufende Entwicklung.",
+      "Meine Arbeit konzentrierte sich auf den Browser-Ablauf vom Datei-Upload über den teilbaren Link bis zum sichtbaren Ablaufdatum im Freigabeprozess.",
+    ],
+    architecture: [
+      "Der Absender lädt eine Datei hoch und legt fest, wie lange sie verfügbar bleiben soll.",
+      "Ventry erstellt einen Link, der den Zugriff auf diese Datei für den gewählten Zeitraum ermöglicht.",
+      "Nach Ablauf endet der Zugriff über den Link und die zugehörige Datei wird automatisch entfernt.",
+    ],
+    technologies: ["typescript", "nextjs"],
+    decisions: [
+      {
+        title: "Das Ablaufdatum gehört zur Freigabe",
+        detail:
+          "Die Laufzeit wird beim Erstellen des Links festgelegt und ist keine getrennte Aufräumoption, an die man sich später erinnern muss.",
+      },
+      {
+        title: "Link und Datei teilen einen Lebenszyklus",
+        detail:
+          "Ein abgelaufener Link und seine gespeicherte Datei bilden einen gemeinsamen Zustandswechsel, damit Zugriff und Aufbewahrung nicht auseinanderlaufen.",
+      },
+      {
+        title: "Ein direkter Browser-Ablauf",
+        detail:
+          "Die zentrale Interaktion bleibt auf Datei, Ablaufdatum und Ergebnis-Link konzentriert, ohne zusätzliche Projektverwaltungsfunktionen einzubauen.",
+      },
+    ],
+    challenges: [
+      {
+        title: "Zugriff und Speicherung müssen übereinstimmen",
+        detail:
+          "Nur den Zugriff zu beenden reicht nicht. Auch die gespeicherte Datei muss derselben Frist folgen, damit ein toter Link keine vergessenen Daten hinterlässt.",
+      },
+      {
+        title: "Aufräumen ohne erneuten Seitenaufruf",
+        detail:
+          "Der Ablauf ist zeitgesteuert und beginnt nicht erst, wenn der Absender die Seite wieder besucht. Die Löschung darf deshalb keine spätere manuelle Interaktion voraussetzen.",
+      },
+    ],
+    outcomes: [
+      "Das Portfolio dokumentiert den Entwicklungszeitraum von Ventry mit 2023 bis 2024.",
+      "Das umgesetzte Konzept verband ablaufende Links mit der automatischen Entfernung der zugehörigen Datei.",
+      "Die öffentliche Seite ventry.host ist weiterhin erreichbar und beschreibt aktuell selbstlöschende Uploads. Daraus folgt keine fortlaufende Entwicklung durch Jan.",
+    ],
+    visuals: [
+      {
+        kind: "diagram",
+        title: "Ein zeitlich begrenzter Datei-Lebenszyklus",
+        description:
+          "Der Ventry-Ablauf koppelt die Verfügbarkeit des Links an die Lebensdauer der gespeicherten Datei.",
+        steps: [
+          "Datei hochladen",
+          "Ablauf festlegen",
+          "Link teilen",
+          "Automatisch entfernen",
         ],
       },
     ],

--- a/src/pages/de/projekte/ventry.astro
+++ b/src/pages/de/projekte/ventry.astro
@@ -1,0 +1,6 @@
+---
+import ProjectCaseStudyPage from "../../../components/pages/ProjectCaseStudyPage.astro";
+import { VENTRY_CASE_STUDIES } from "../../../data/project-content";
+---
+
+<ProjectCaseStudyPage content={VENTRY_CASE_STUDIES.de} />

--- a/src/pages/en/projects/ventry.astro
+++ b/src/pages/en/projects/ventry.astro
@@ -1,0 +1,6 @@
+---
+import ProjectCaseStudyPage from "../../../components/pages/ProjectCaseStudyPage.astro";
+import { VENTRY_CASE_STUDIES } from "../../../data/project-content";
+---
+
+<ProjectCaseStudyPage content={VENTRY_CASE_STUDIES.en} />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -66,7 +66,7 @@ const linkedinUrl =
         ventry={copy.ventry}
         projectPaths={{
           finny: PROJECT_ROUTES[locale].finny,
-          ventry: `${PROJECT_ROUTES[locale].index}#ventry`,
+          ventry: PROJECT_ROUTES[locale].ventry,
         }}
       />
       <WaveDivider />


### PR DESCRIPTION
## Summary

- publish complete English and German Ventry case studies covering the problem, Jan's role, lifecycle architecture, technologies, decisions, challenges and project status
- represent the 2023–2024 development period separately from the currently reachable public product site
- add an original accessible, responsive upload-to-removal process diagram and link the localized homepage and project index directly to each case study
- add localized metadata, canonical and reciprocal hreflang links, sitemap, browser, Article schema and Lighthouse coverage without unsupported usage claims

## Validation

- `bun run ci`
- desktop visual QA at 1440×1000
- mobile visual QA at 390×844

Closes #38
