### PR TITLE
Suggest German version to German browsers

### DIFF
--- a/scripts/browser-smoke.mjs
+++ b/scripts/browser-smoke.mjs
@@ -262,6 +262,7 @@ try {
     headless: true,
   });
   const context = await browser.newContext({
+    locale: "en-US",
     viewport: { width: 1440, height: 1000 },
   });
   let interceptedAnalyticsRequests = 0;
@@ -305,6 +306,7 @@ try {
   });
 
   await page.goto(baseUrl, { waitUntil: "networkidle" });
+  assert.equal(await page.locator("#language-suggestion").isHidden(), true);
   const analyticsHost = await page
     .locator('meta[name="posthog-api-host"]')
     .getAttribute("content");
@@ -361,6 +363,65 @@ try {
     );
   }
   await semanticPage.close();
+
+  const germanLocaleContext = await browser.newContext({
+    locale: "de-DE",
+    viewport: { width: 1440, height: 1000 },
+  });
+  const germanLocalePage = await germanLocaleContext.newPage();
+  await germanLocalePage.goto(`${baseUrl}/en`);
+  const languageSuggestion = germanLocalePage.locator("#language-suggestion");
+  await assert.doesNotReject(() =>
+    languageSuggestion.waitFor({ state: "visible" }),
+  );
+  assert.equal(
+    await germanLocalePage
+      .locator("#language-suggestion-accept")
+      .getAttribute("href"),
+    "/de",
+  );
+  await germanLocalePage.locator("#language-suggestion-dismiss").click();
+  await assert.doesNotReject(() =>
+    languageSuggestion.waitFor({ state: "hidden" }),
+  );
+  assert.equal(
+    await germanLocalePage.evaluate(() =>
+      globalThis.localStorage.getItem("itsjan-language-suggestion"),
+    ),
+    "dismissed",
+  );
+  await germanLocalePage.reload();
+  assert.equal(await languageSuggestion.isHidden(), true);
+
+  await germanLocalePage.evaluate(() =>
+    globalThis.localStorage.removeItem("itsjan-language-suggestion"),
+  );
+  await germanLocalePage.goto(`${baseUrl}/en/privacy`);
+  await assert.doesNotReject(() =>
+    languageSuggestion.waitFor({ state: "visible" }),
+  );
+  assert.equal(
+    await germanLocalePage
+      .locator("#language-suggestion-accept")
+      .getAttribute("href"),
+    "/de/datenschutz",
+  );
+  await Promise.all([
+    germanLocalePage.waitForURL(`${baseUrl}/de/datenschutz`),
+    germanLocalePage.locator("#language-suggestion-accept").click(),
+  ]);
+  assert.equal(
+    await germanLocalePage.evaluate(() =>
+      globalThis.localStorage.getItem("itsjan-language-suggestion"),
+    ),
+    "accepted",
+  );
+  assert.equal(
+    await germanLocalePage.locator("#language-suggestion").count(),
+    0,
+  );
+  await germanLocaleContext.close();
+
   assert.equal(await page.locator(".activity-reveal").count(), 1);
   assert.equal(await page.locator(".activity-reveal [tabindex]").count(), 0);
   assert.ok(

--- a/src/components/LanguageSuggestion.astro
+++ b/src/components/LanguageSuggestion.astro
@@ -19,25 +19,27 @@ const { germanPath } = Astro.props;
       aria-labelledby="language-suggestion-title"
       hidden
     >
-      <p id="language-suggestion-title" class="language-suggestion__title">
-        Möchtest du diese Seite auf Deutsch ansehen?
-      </p>
-      <div class="language-suggestion__actions">
-        <InteractiveButton
-          id="language-suggestion-dismiss"
-          class="language-suggestion__dismiss"
-          variant="text"
-        >
-          Nein, danke
-        </InteractiveButton>
-        <InteractiveLink
-          id="language-suggestion-accept"
-          class="language-suggestion__accept"
-          variant="primary"
-          href={germanPath}
-        >
-          Deutsch anzeigen
-        </InteractiveLink>
+      <div class="language-suggestion__surface">
+        <p id="language-suggestion-title" class="language-suggestion__title">
+          Möchtest du diese Seite auf Deutsch ansehen?
+        </p>
+        <div class="language-suggestion__actions">
+          <InteractiveButton
+            id="language-suggestion-dismiss"
+            class="language-suggestion__dismiss"
+            variant="text"
+          >
+            Nein, danke
+          </InteractiveButton>
+          <InteractiveLink
+            id="language-suggestion-accept"
+            class="language-suggestion__accept"
+            variant="primary"
+            href={germanPath}
+          >
+            Deutsch anzeigen
+          </InteractiveLink>
+        </div>
       </div>
     </aside>
   )

--- a/src/components/LanguageSuggestion.astro
+++ b/src/components/LanguageSuggestion.astro
@@ -1,0 +1,96 @@
+---
+import InteractiveButton from "./InteractiveButton.astro";
+import InteractiveLink from "./InteractiveLink.astro";
+
+interface Props {
+  germanPath?: string;
+}
+
+const { germanPath } = Astro.props;
+---
+
+{
+  germanPath && (
+    <aside
+      id="language-suggestion"
+      class="language-suggestion"
+      role="dialog"
+      aria-modal="false"
+      aria-labelledby="language-suggestion-title"
+      hidden
+    >
+      <p id="language-suggestion-title" class="language-suggestion__title">
+        Möchtest du diese Seite auf Deutsch ansehen?
+      </p>
+      <div class="language-suggestion__actions">
+        <InteractiveButton
+          id="language-suggestion-dismiss"
+          class="language-suggestion__dismiss"
+          variant="text"
+        >
+          Nein, danke
+        </InteractiveButton>
+        <InteractiveLink
+          id="language-suggestion-accept"
+          class="language-suggestion__accept"
+          variant="primary"
+          href={germanPath}
+        >
+          Deutsch anzeigen
+        </InteractiveLink>
+      </div>
+    </aside>
+  )
+}
+
+<script>
+  (() => {
+    const storageKey = "itsjan-language-suggestion";
+    const suggestion = document.getElementById("language-suggestion");
+    const accept = document.getElementById("language-suggestion-accept");
+    const dismiss = document.getElementById("language-suggestion-dismiss");
+    if (
+      !(suggestion instanceof HTMLElement) ||
+      !(accept instanceof HTMLAnchorElement) ||
+      !(dismiss instanceof HTMLButtonElement)
+    )
+      return;
+
+    const primaryLocale = navigator.languages?.[0] ?? navigator.language;
+    const prefersGerman = /^de(?:-|$)/i.test(primaryLocale);
+    let storedChoice = null;
+    try {
+      storedChoice = window.localStorage.getItem(storageKey);
+    } catch {
+      // The suggestion still works for this page when storage is unavailable.
+    }
+    if (!prefersGerman || storedChoice) return;
+
+    const saveChoice = (choice: "accepted" | "dismissed") => {
+      try {
+        window.localStorage.setItem(storageKey, choice);
+      } catch {
+        // Keep the in-page choice even when storage is unavailable.
+      }
+    };
+    const hide = () => {
+      suggestion.classList.remove("is-visible");
+      window.setTimeout(() => {
+        suggestion.hidden = true;
+      }, 180);
+    };
+    const dismissSuggestion = () => {
+      saveChoice("dismissed");
+      hide();
+    };
+
+    suggestion.hidden = false;
+    window.requestAnimationFrame(() => suggestion.classList.add("is-visible"));
+    accept.addEventListener("click", () => saveChoice("accepted"));
+    dismiss.addEventListener("click", dismissSuggestion);
+    suggestion.addEventListener("keydown", (event) => {
+      if (event.key !== "Escape") return;
+      dismissSuggestion();
+    });
+  })();
+</script>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -4,6 +4,7 @@ import "../styles/global.css";
 import CookieConsent from "../components/CookieConsent.astro";
 import ConsoleEasterEgg from "../components/ConsoleEasterEgg.astro";
 import InteractionRuntime from "../components/InteractionRuntime.astro";
+import LanguageSuggestion from "../components/LanguageSuggestion.astro";
 import PostHog from "../components/posthog.astro";
 import { detectLocale, tr } from "../lib/i18n";
 import type { Locale } from "../lib/locale";
@@ -182,6 +183,9 @@ if (requestUrl.pathname === "/" || requestUrl.pathname === "") {
   </head>
   <body>
     <slot />
+    <LanguageSuggestion
+      germanPath={locale === "en" ? alternatePaths?.de : undefined}
+    />
     <CookieConsent locale={locale} />
     <ConsoleEasterEgg locale={locale} />
     <InteractionRuntime />

--- a/src/styles/features/language-suggestion.css
+++ b/src/styles/features/language-suggestion.css
@@ -1,0 +1,86 @@
+.language-suggestion {
+  position: fixed;
+  z-index: 110;
+  top: max(16px, env(safe-area-inset-top));
+  left: 50%;
+  display: flex;
+  width: min(calc(100% - 32px), 600px);
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 14px 16px;
+  border-radius: 16px;
+  background: color-mix(in srgb, var(--surface) 96%, transparent);
+  box-shadow:
+    var(--shadow-border),
+    0 18px 48px rgba(17, 18, 20, 0.16);
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(-50%, -10px) scale(0.98);
+  transition-property: opacity, transform;
+  transition-duration: 180ms;
+  transition-timing-function: var(--ease-smooth-out);
+  -webkit-backdrop-filter: blur(14px);
+  backdrop-filter: blur(14px);
+}
+.language-suggestion[hidden] {
+  display: none;
+}
+.language-suggestion.is-visible {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translate(-50%, 0) scale(1);
+}
+.language-suggestion__title {
+  margin: 0;
+  color: var(--text);
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.45;
+  text-wrap: pretty;
+}
+.language-suggestion__actions {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 12px;
+}
+.language-suggestion__dismiss {
+  min-height: 34px;
+  padding: 0 2px;
+  font: inherit;
+  font-size: 0.8125rem;
+  font-weight: 500;
+}
+.language-suggestion__accept {
+  min-height: 34px;
+}
+@media (max-width: 600px) {
+  .language-suggestion {
+    top: max(12px, env(safe-area-inset-top));
+    width: calc(100% - 24px);
+    align-items: stretch;
+    flex-direction: column;
+    gap: 14px;
+    padding: 16px;
+  }
+  .language-suggestion__actions {
+    justify-content: flex-end;
+  }
+}
+@media (max-width: 390px) {
+  .language-suggestion__actions {
+    align-items: stretch;
+    flex-direction: column-reverse;
+  }
+  .language-suggestion__dismiss,
+  .language-suggestion__accept {
+    width: 100%;
+    justify-content: center;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .language-suggestion {
+    transition: none;
+  }
+}

--- a/src/styles/features/language-suggestion.css
+++ b/src/styles/features/language-suggestion.css
@@ -3,25 +3,13 @@
   z-index: 110;
   top: max(16px, env(safe-area-inset-top));
   left: 50%;
-  display: flex;
-  width: min(calc(100% - 32px), 600px);
-  align-items: center;
-  justify-content: space-between;
-  gap: 20px;
-  padding: 14px 16px;
-  border-radius: 16px;
-  background: color-mix(in srgb, var(--surface) 96%, transparent);
-  box-shadow:
-    var(--shadow-border),
-    0 18px 48px rgba(17, 18, 20, 0.16);
+  width: min(calc(100% - 32px), 640px);
   opacity: 0;
   pointer-events: none;
   transform: translate(-50%, -10px) scale(0.98);
   transition-property: opacity, transform;
   transition-duration: 180ms;
   transition-timing-function: var(--ease-smooth-out);
-  -webkit-backdrop-filter: blur(14px);
-  backdrop-filter: blur(14px);
 }
 .language-suggestion[hidden] {
   display: none;
@@ -30,6 +18,13 @@
   opacity: 1;
   pointer-events: auto;
   transform: translate(-50%, 0) scale(1);
+}
+.language-suggestion__surface {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 14px 16px;
 }
 .language-suggestion__title {
   margin: 0;
@@ -59,6 +54,8 @@
   .language-suggestion {
     top: max(12px, env(safe-area-inset-top));
     width: calc(100% - 24px);
+  }
+  .language-suggestion__surface {
     align-items: stretch;
     flex-direction: column;
     gap: 14px;
@@ -80,7 +77,8 @@
   }
 }
 @media (prefers-reduced-motion: reduce) {
-  .language-suggestion {
+  .language-suggestion,
+  .language-suggestion__surface {
     transition: none;
   }
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -512,6 +512,8 @@ html.is-theme-changing .profile-avatar,
 html.is-theme-changing .experience-technology,
 html.is-theme-changing .project-preview,
 html.is-theme-changing .project-preview-surface,
+html.is-theme-changing .language-suggestion,
+html.is-theme-changing .language-suggestion__surface,
 html.is-theme-changing .project-preview-action::before {
   transition: none !important;
 }
@@ -703,6 +705,7 @@ html[data-theme="dark"]
 }
 
 .project-preview,
+.language-suggestion,
 .social-preview__viewport {
   padding: 8px;
   border-radius: 22px;
@@ -720,6 +723,7 @@ html[data-theme="dark"]
   transition-timing-function: var(--ease-smooth-out);
 }
 .project-preview-surface,
+.language-suggestion__surface,
 .social-preview__panel {
   overflow: hidden;
   border-radius: 14px;
@@ -1880,6 +1884,8 @@ html[data-theme="dark"] .social-card-linkedin-action {
   .project-preview,
   .project-preview-surface,
   .project-preview-image,
+  .language-suggestion,
+  .language-suggestion__surface,
   .social-preview__viewport,
   .social-preview__panel,
   .avatar-modal-content,
@@ -1889,6 +1895,7 @@ html[data-theme="dark"] .social-card-linkedin-action {
     corner-shape: squircle;
   }
   .project-preview,
+  .language-suggestion,
   .social-preview__viewport {
     border-radius: 22px;
   }
@@ -2127,6 +2134,8 @@ html[data-theme="dark"] .social-card-linkedin-action {
   .project-preview,
   .project-preview-surface,
   .project-preview-image,
+  .language-suggestion,
+  .language-suggestion__surface,
   .project-preview-action::before,
   .profile-avatar,
   .theme-toggle,

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @import "./tokens.css";
+@import "./features/language-suggestion.css";
 @import "./features/privacy.css";
 
 * {


### PR DESCRIPTION
## Summary
- show a one-time German-language suggestion on English pages when the primary browser locale is German
- route visitors to the matching localized page and remember accept or dismiss choices locally
- add responsive styling and browser coverage for English, German, dismiss, persistence, and navigation states

## Validation
- `bun run ci`
- Playwright visual QA at 1440x1000 and 375x812